### PR TITLE
Fix argument order of step function

### DIFF
--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -418,13 +418,13 @@ namespace Unity.Mathematics
 
         //Step
         [MethodImpl((MethodImplOptions)0x100)] // agressive inline
-        public static float step(float a, float b) { return select(0.0f, 1.0f, a >= b); }
+        public static float step(float a, float b) { return select(0.0f, 1.0f, b >= a); }
         [MethodImpl((MethodImplOptions)0x100)] // agressive inline
-        public static float2 step(float2 a, float2 b) { return select(0.0f, 1.0f, a >= b); }
+        public static float2 step(float2 a, float2 b) { return select(0.0f, 1.0f, b >= a); }
         [MethodImpl((MethodImplOptions)0x100)] // agressive inline
-        public static float3 step(float3 a, float3 b) { return select(0.0f, 1.0f, a >= b); }
+        public static float3 step(float3 a, float3 b) { return select(0.0f, 1.0f, b >= a); }
         [MethodImpl((MethodImplOptions)0x100)] // agressive inline
-        public static float4 step(float4 a, float4 b) { return select(0.0f, 1.0f, a >= b); }
+        public static float4 step(float4 a, float4 b) { return select(0.0f, 1.0f, b >= a); }
 
         [MethodImpl((MethodImplOptions)0x100)] // agressive inline
         public static float reflect(float i, float n) { return i - 2f * n * dot(i, n); }


### PR DESCRIPTION
This pull request is to fix the argument order of `math.step`.

In most shader languages, the first argument of the `step` function specifies the edge, and the input value is given via the second argument.

- https://msdn.microsoft.com/en-us/library/windows/desktop/bb509665(v=vs.85).aspx
- https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/step.xhtml

However, this order is inversed in the current implementation:

https://github.com/Unity-Technologies/Unity.Mathematics/blob/b725e194ce6109a2aef32c712ea260dedd276ca1/src/Unity.Mathematics/math.cs#L421

This causes strange artifacts when using the noise functions. The following screenshot shows a visualization of `noise.snoise(float3)`.

![screenshot](https://i.imgur.com/9i4ndT3m.jpg)

The artifacts disappear after applying this fix.

![screenshot](https://i.imgur.com/gou1WTrm.jpg)
