### PR TITLE
Add PropertyDrawers for Intrinsic Types

### DIFF
--- a/src/Unity.Mathematics.Editor.meta
+++ b/src/Unity.Mathematics.Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed3cf288b647446a1a4040049eb363d7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Unity.Mathematics.Editor/PropertyDrawers.cs
+++ b/src/Unity.Mathematics.Editor/PropertyDrawers.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.Mathematics.Editor
+{
+    [CustomPropertyDrawer(typeof(bool2)), CustomPropertyDrawer(typeof(bool3)), CustomPropertyDrawer(typeof(bool4))]
+    [CustomPropertyDrawer(typeof(double2)), CustomPropertyDrawer(typeof(double3)), CustomPropertyDrawer(typeof(double4))]
+    [CustomPropertyDrawer(typeof(float2)), CustomPropertyDrawer(typeof(float3)), CustomPropertyDrawer(typeof(float4))]
+    [CustomPropertyDrawer(typeof(int2)), CustomPropertyDrawer(typeof(int3)), CustomPropertyDrawer(typeof(int4))]
+    [CustomPropertyDrawer(typeof(uint2)), CustomPropertyDrawer(typeof(uint3)), CustomPropertyDrawer(typeof(uint4))]
+    [CustomPropertyDrawer(typeof(quaternion))]
+    public class MultiDrawer1D : PropertyDrawer
+    {
+        static readonly GUIContent[] k_Labels2 = { new GUIContent("X"), new GUIContent("Y") };
+        static readonly GUIContent[] k_Labels3 = { new GUIContent("X"), new GUIContent("Y"), new GUIContent("Z") };
+        static readonly GUIContent[] k_Labels4 = { new GUIContent("X"), new GUIContent("Y"), new GUIContent("Z"), new GUIContent("W") };
+
+        public override bool CanCacheInspectorGUI(SerializedProperty property)
+        {
+            return false;
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            var height = EditorGUIUtility.singleLineHeight;
+            if (!EditorGUIUtility.wideMode)
+                height += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            return height;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var subLabels = k_Labels4;
+            var startIter = "x";
+            if (property.type[property.type.Length - 1] == '3')
+                subLabels = k_Labels3;
+            else if (property.type[property.type.Length - 1] == '2')
+                subLabels = k_Labels2;
+            else if (property.type == nameof(quaternion))
+                startIter = "value.x";
+
+            EditorGUI.MultiPropertyField(position, subLabels, property.FindPropertyRelative(startIter), label);
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(bool2x2)), CustomPropertyDrawer(typeof(bool2x3)), CustomPropertyDrawer(typeof(bool2x4))]
+    [CustomPropertyDrawer(typeof(bool3x2)), CustomPropertyDrawer(typeof(bool3x3)), CustomPropertyDrawer(typeof(bool3x4))]
+    [CustomPropertyDrawer(typeof(bool4x2)), CustomPropertyDrawer(typeof(bool4x3)), CustomPropertyDrawer(typeof(bool4x4))]
+    [CustomPropertyDrawer(typeof(double2x2)), CustomPropertyDrawer(typeof(double2x3)), CustomPropertyDrawer(typeof(double2x4))]
+    [CustomPropertyDrawer(typeof(double3x2)), CustomPropertyDrawer(typeof(double3x3)), CustomPropertyDrawer(typeof(double3x4))]
+    [CustomPropertyDrawer(typeof(double4x2)), CustomPropertyDrawer(typeof(double4x3)), CustomPropertyDrawer(typeof(double4x4))]
+    [CustomPropertyDrawer(typeof(float2x2)), CustomPropertyDrawer(typeof(float2x3)), CustomPropertyDrawer(typeof(float2x4))]
+    [CustomPropertyDrawer(typeof(float3x2)), CustomPropertyDrawer(typeof(float3x3)), CustomPropertyDrawer(typeof(float3x4))]
+    [CustomPropertyDrawer(typeof(float4x2)), CustomPropertyDrawer(typeof(float4x3)), CustomPropertyDrawer(typeof(float4x4))]
+    [CustomPropertyDrawer(typeof(int2x2)), CustomPropertyDrawer(typeof(int2x3)), CustomPropertyDrawer(typeof(int2x4))]
+    [CustomPropertyDrawer(typeof(int3x2)), CustomPropertyDrawer(typeof(int3x3)), CustomPropertyDrawer(typeof(int3x4))]
+    [CustomPropertyDrawer(typeof(int4x2)), CustomPropertyDrawer(typeof(int4x3)), CustomPropertyDrawer(typeof(int4x4))]
+    [CustomPropertyDrawer(typeof(uint2x2)), CustomPropertyDrawer(typeof(uint2x3)), CustomPropertyDrawer(typeof(uint2x4))]
+    [CustomPropertyDrawer(typeof(uint3x2)), CustomPropertyDrawer(typeof(uint3x3)), CustomPropertyDrawer(typeof(uint3x4))]
+    [CustomPropertyDrawer(typeof(uint4x2)), CustomPropertyDrawer(typeof(uint4x3)), CustomPropertyDrawer(typeof(uint4x4))]
+    public class MultiDrawerMxN : PropertyDrawer
+    {
+        public override bool CanCacheInspectorGUI(SerializedProperty property)
+        {
+            return false;
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (!property.isExpanded)
+                return EditorGUIUtility.singleLineHeight;
+            var rows = 1 + property.type[property.type.Length - 3] - '0';
+            return rows * EditorGUIUtility.singleLineHeight + (rows - 1) * EditorGUIUtility.standardVerticalSpacing;
+        }
+
+        static ReadOnlyCollection<string> k_ColPropertyPaths =
+            new ReadOnlyCollection<string>(new[] { "c0", "c1", "c2", "c3" });
+        static ReadOnlyCollection<string> k_RowPropertyPaths =
+            new ReadOnlyCollection<string>(new[] { "x", "y", "z", "w" });
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            position.height = EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(position, property, label, false);
+
+            if (Event.current.type == EventType.ContextClick && position.Contains(Event.current.mousePosition))
+            {
+                DoUtilityMenu(property);
+                Event.current.Use();
+            }
+
+            if (!property.isExpanded)
+                return;
+
+            var rows = property.type[property.type.Length - 3] - '0';
+            var cols = property.type[property.type.Length - 1] - '0';
+
+            ++EditorGUI.indentLevel;
+            position = EditorGUI.IndentedRect(position);
+            --EditorGUI.indentLevel;
+
+            var elementType = property.FindPropertyRelative("c0.x").propertyType;
+            for (var row = 0; row < rows; ++row)
+            {
+                position.y += position.height + EditorGUIUtility.standardVerticalSpacing;
+                var elementRect = new Rect(position)
+                {
+                    width = elementType == SerializedPropertyType.Boolean
+                        ? EditorGUIUtility.singleLineHeight
+                        : (position.width - (cols - 1) * EditorGUIUtility.standardVerticalSpacing) / cols
+                };
+                for (var col = 0; col < cols; ++col)
+                {
+                    EditorGUI.PropertyField(
+                        elementRect,
+                        property.FindPropertyRelative($"{k_ColPropertyPaths[col]}.{k_RowPropertyPaths[row]}"),
+                        GUIContent.none
+                    );
+                    elementRect.x += elementRect.width + EditorGUIUtility.standardVerticalSpacing;
+                }
+            }
+        }
+
+        Dictionary<SerializedPropertyType, Action<SerializedProperty, bool>> k_UtilityValueSetters =
+            new Dictionary<SerializedPropertyType, Action<SerializedProperty, bool>>
+            {
+                { SerializedPropertyType.Boolean, (property, b) => property.boolValue = b },
+                { SerializedPropertyType.Float, (property, b) => property.floatValue = b ? 1f : 0f },
+                { SerializedPropertyType.Integer, (property, b) => property.intValue = b ? 1 : 0 }
+            };
+
+        void DoUtilityMenu(SerializedProperty property)
+        {
+            var rows = property.type[property.type.Length - 3] - '0';
+            var cols = property.type[property.type.Length - 1] - '0';
+            var elementType = property.FindPropertyRelative("c0.x").propertyType;
+            var setValue = k_UtilityValueSetters[elementType];
+            var menu = new GenericMenu();
+            property = property.Copy();
+            menu.AddItem(
+                EditorGUIUtility.TrTextContent("Set to Zero"),
+                false,
+                () =>
+                {
+                    property.serializedObject.Update();;
+                    for (var row = 0; row < rows; ++row)
+                    for (var col = 0; col < cols; ++col)
+                        setValue(
+                            property.FindPropertyRelative($"{k_ColPropertyPaths[col]}.{k_RowPropertyPaths[row]}"),
+                            false
+                        );
+                    property.serializedObject.ApplyModifiedProperties();
+                }
+            );
+            if (rows == cols)
+            {
+                menu.AddItem(
+                    EditorGUIUtility.TrTextContent("Reset to Identity"),
+                    false,
+                    () =>
+                    {
+                        property.serializedObject.Update();
+                        for (var row = 0; row < rows; ++row)
+                        for (var col = 0; col < cols; ++col)
+                            setValue(
+                                property.FindPropertyRelative($"{k_ColPropertyPaths[col]}.{k_RowPropertyPaths[row]}"),
+                                row == col
+                            );
+                        property.serializedObject.ApplyModifiedProperties();
+                    }
+                );
+            }
+            menu.ShowAsContext();
+        }
+    }
+}

--- a/src/Unity.Mathematics.Editor/PropertyDrawers.cs.meta
+++ b/src/Unity.Mathematics.Editor/PropertyDrawers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 407410bec194a4cfe929933685bb80a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Unity.Mathematics.Editor/Unity.Mathematics.Editor.asmdef
+++ b/src/Unity.Mathematics.Editor/Unity.Mathematics.Editor.asmdef
@@ -1,0 +1,12 @@
+{
+    "name": "Unity.Mathematics.Editor",
+    "references": [
+        "Unity.Mathematics"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true
+}

--- a/src/Unity.Mathematics.Editor/Unity.Mathematics.Editor.asmdef.meta
+++ b/src/Unity.Mathematics.Editor/Unity.Mathematics.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 329b4ccd385744985bf3f83cfd77dfe7
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add PropertyDrawers for intrinsic types (e.g., bool/double/float/int/uintN and MxN, as well as quaternion).

I haven't updated csproj or sln since I wasn't sure what your organizational preferences were, but I tested pointing my package manifest at my local copy.

**Bool Examples**
(Narrow)
![bool](https://user-images.githubusercontent.com/981828/45305607-00fb1700-b51b-11e8-9c06-a4adf0afdffa.png)
(Wide)
![bool-wide](https://user-images.githubusercontent.com/981828/45305610-00fb1700-b51b-11e8-9b70-b72abde1b0ae.png)
**Numeric Examples**
(Narrow)
![double](https://user-images.githubusercontent.com/981828/45305611-00fb1700-b51b-11e8-964c-5e7c8352a574.png)
(Wide)
![double-wide](https://user-images.githubusercontent.com/981828/45305612-0193ad80-b51b-11e8-807a-2d7c2f4ca329.png)
**Quaternion Examples**
(Narrow)
![quaternion](https://user-images.githubusercontent.com/981828/45305613-0193ad80-b51b-11e8-8098-9df5c19a4497.png)
(Wide)
![quaternion-wide](https://user-images.githubusercontent.com/981828/45305614-0193ad80-b51b-11e8-991e-9d47a7d288d6.png)
