### PR TITLE
DBL_MIN_NORMAL set to the actual smallest positive normal number representable in a double

### DIFF
--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -72,7 +72,7 @@ namespace Unity.Mathematics
         public static readonly float FLT_MIN_NORMAL = 1.175494351e-38F;
 
         /// <summary>The smallest positive normal number representable in a double.</summary>
-        public static readonly float DBL_MIN_NORMAL = 1.175494351e-38F;
+        public static readonly double DBL_MIN_NORMAL = 2.2250738585072014e-308;
 
 
         /// <summary>Returns the bit pattern of a uint as an int.</summary>


### PR DESCRIPTION
Seems to be a copy and paste oversight, since it was equal to FLT_MIN_NORMAL.
Source for the number: https://msdn.microsoft.com/en-us/library/hd7199ke.aspx#Range-of-Floating-Point-Types