### PR TITLE
Math functions reference table had broken markdown past `ror`

### DIFF
--- a/doc/references.md
+++ b/doc/references.md
@@ -76,7 +76,6 @@ The following table shows the list of intrinsic functions exposed by the static 
 |reversebits     | [x](https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/dx-graphics-hlsl-reversebits) | Returns the result of performing a componentwise reversal of the bit pattern of an integer vector or scalar.
 |rol             |   | Returns the result of a componentwise left rotation by n bits of the bit pattern of an integer vector or scalar.
 |ror             |   | Returns the result of a componentwise right rotation by n bits of the bit pattern of an integer vector or scalar.
-
 |rotate          |   |
 |round           | [x](https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/dx-graphics-hlsl-round) | Returns the result of rounding each component of a vector or scalar to the nearest integral value.
 |rsqrt           | [x](https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/dx-graphics-hlsl-rsqrt) | Returns the componentwise reciprocal square root of a scalar or vector value.


### PR DESCRIPTION
An extra newline was turning rest of text into a non-table