### PR TITLE
Added Random.CreateFromIndex().

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Not yet released]
+## [Unreleased]
 - Adding Random.CreateFromHashedSeed() to assist in creating Random instances with consecutive seeds.
 
 ## [1.1.0] - 2019-07-08

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- Adding Random.CreateFromHashedSeed() to assist in creating Random instances with consecutive seeds.
+- Adding Random.CreateFromIndex() to assist in creating Random instances from loop indices.
 
 ## [1.1.0] - 2019-07-08
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Not yet released]
+- Adding Random.CreateFromHashedSeed() to assist in creating Random instances with consecutive seeds.
+
 ## [1.1.0] - 2019-07-08
 
 - Release stable version

--- a/src/Tests/Tests/TestRandom.cs
+++ b/src/Tests/Tests/TestRandom.cs
@@ -1187,11 +1187,11 @@ namespace Unity.Mathematics.Tests
         public static void consecutive_seeds_r_test()
         {
             // Check that drawing 1 number from many consecutive seeds has no correlation.
-            for (uint i = 1; i < 128; ++i)
+            for (uint i = 0; i < 128; ++i)
             {
                 uint seed1 = i;
                 uint seed2 = i + 1;
-                r_test(() => new double2(Random.CreateFromHashedSeed(seed1++).NextUInt(), Random.CreateFromHashedSeed(seed2++).NextUInt()));
+                r_test(() => new double2(Random.CreateFromIndex(seed1++).NextUInt(), Random.CreateFromIndex(seed2++).NextUInt()));
             }
         }
 
@@ -1203,7 +1203,7 @@ namespace Unity.Mathematics.Tests
             {
                 uint seed1 = 0x6E624EB7u + i;
                 uint seed2 = 0x6E624EB8u + i;
-                r_test(() => new double2(Random.CreateFromHashedSeed(seed1++).NextUInt(), Random.CreateFromHashedSeed(seed2++).NextUInt()));
+                r_test(() => new double2(Random.CreateFromIndex(seed1++).NextUInt(), Random.CreateFromIndex(seed2++).NextUInt()));
             }
         }
 
@@ -1211,8 +1211,8 @@ namespace Unity.Mathematics.Tests
         public static void consecutive_seeds_ks_test()
         {
             // Check that drawing 1 number from many consecutive seeds matches our expected distribution.
-            uint seed = 1;
-            ks_test(() => Random.CreateFromHashedSeed(seed++).NextDouble());
+            uint seed = 0;
+            ks_test(() => Random.CreateFromIndex(seed++).NextDouble());
         }
 
         [TestCompiler]
@@ -1220,7 +1220,7 @@ namespace Unity.Mathematics.Tests
         {
             // Check that drawing 1 number from many consecutive seeds matches our expected distribution.
             uint seed = 0x6E624EB7u;
-            ks_test(() => Random.CreateFromHashedSeed(seed++).NextDouble());
+            ks_test(() => Random.CreateFromIndex(seed++).NextDouble());
         }
 
         [TestCompiler]

--- a/src/Tests/Tests/TestRandom.cs
+++ b/src/Tests/Tests/TestRandom.cs
@@ -1187,7 +1187,7 @@ namespace Unity.Mathematics.Tests
         public static void consecutive_seeds_r_test()
         {
             // Check that drawing 1 number from many consecutive seeds has no correlation.
-            for (uint i = 0; i < 128; ++i)
+            for (uint i = 1; i < 128; ++i)
             {
                 uint seed1 = i;
                 uint seed2 = i + 1;
@@ -1211,7 +1211,7 @@ namespace Unity.Mathematics.Tests
         public static void consecutive_seeds_ks_test()
         {
             // Check that drawing 1 number from many consecutive seeds matches our expected distribution.
-            uint seed = 0;
+            uint seed = 1;
             ks_test(() => Random.CreateFromHashedSeed(seed++).NextDouble());
         }
 
@@ -1247,16 +1247,6 @@ namespace Unity.Mathematics.Tests
                 var rnd2 = new Random(0x6E624EB8u + i);
                 r_test(() => new double2(rnd1.NextUInt(), rnd2.NextUInt()));
             }
-        }
-
-        [TestCompiler]
-        public static void hashed_seed_backup()
-        {
-            // 61 hashes to zero which breaks Random.  This checks that the backup is used instead.
-            uint backup = 1337u;
-            var rnd = Random.CreateFromHashedSeed(61u, backup);
-            var rnd_with_backup = new Random(backup);
-            Assert.AreEqual(rnd_with_backup.state, rnd.state);
         }
     }
 }

--- a/src/Tests/Tests/TestRandom.cs
+++ b/src/Tests/Tests/TestRandom.cs
@@ -1182,5 +1182,81 @@ namespace Unity.Mathematics.Tests
                 return double2(phi, z);
             });
         }
+
+        [TestCompiler]
+        public static void consecutive_seeds_r_test()
+        {
+            // Check that drawing 1 number from many consecutive seeds has no correlation.
+            for (uint i = 0; i < 128; ++i)
+            {
+                uint seed1 = i;
+                uint seed2 = i + 1;
+                r_test(() => new double2(Random.CreateFromHashedSeed(seed1++).NextUInt(), Random.CreateFromHashedSeed(seed2++).NextUInt()));
+            }
+        }
+
+        [TestCompiler]
+        public static void consecutive_seeds_r_test2()
+        {
+            // Check that drawing 1 number from many consecutive seeds has no correlation.
+            for (uint i = 0; i < 128; ++i)
+            {
+                uint seed1 = 0x6E624EB7u + i;
+                uint seed2 = 0x6E624EB8u + i;
+                r_test(() => new double2(Random.CreateFromHashedSeed(seed1++).NextUInt(), Random.CreateFromHashedSeed(seed2++).NextUInt()));
+            }
+        }
+
+        [TestCompiler]
+        public static void consecutive_seeds_ks_test()
+        {
+            // Check that drawing 1 number from many consecutive seeds matches our expected distribution.
+            uint seed = 0;
+            ks_test(() => Random.CreateFromHashedSeed(seed++).NextDouble());
+        }
+
+        [TestCompiler]
+        public static void consecutive_seeds_ks_test2()
+        {
+            // Check that drawing 1 number from many consecutive seeds matches our expected distribution.
+            uint seed = 0x6E624EB7u;
+            ks_test(() => Random.CreateFromHashedSeed(seed++).NextDouble());
+        }
+
+        [TestCompiler]
+        public static void similar_seeds()
+        {
+            // Check to see that two consecutive seeds have no correlation when drawing
+            // many numbers from them.
+            for (uint i = 1; i <= 1024; ++i)
+            {
+                var rnd1 = new Random(i);
+                var rnd2 = new Random(i + 1);
+                r_test(() => new double2(rnd1.NextUInt(), rnd2.NextUInt()));
+            }
+        }
+
+        [TestCompiler]
+        public static void similar_seeds2()
+        {
+            // Check to see that two consecutive seeds have no correlation when drawing
+            // many numbers from them.
+            for (uint i = 0; i < 1024; ++i)
+            {
+                var rnd1 = new Random(0x6E624EB7u + i);
+                var rnd2 = new Random(0x6E624EB8u + i);
+                r_test(() => new double2(rnd1.NextUInt(), rnd2.NextUInt()));
+            }
+        }
+
+        [TestCompiler]
+        public static void hashed_seed_backup()
+        {
+            // 61 hashes to zero which breaks Random.  This checks that the backup is used instead.
+            uint backup = 1337u;
+            var rnd = Random.CreateFromHashedSeed(61u, backup);
+            var rnd_with_backup = new Random(backup);
+            Assert.AreEqual(rnd_with_backup.state, rnd.state);
+        }
     }
 }

--- a/src/Tests/Tests/TestRandom.cs
+++ b/src/Tests/Tests/TestRandom.cs
@@ -1248,5 +1248,26 @@ namespace Unity.Mathematics.Tests
                 r_test(() => new double2(rnd1.NextUInt(), rnd2.NextUInt()));
             }
         }
+
+        [TestCompiler]
+        public static void wang_hash()
+        {
+            TestUtils.AreEqual(3232319850u, Random.WangHash(0u));
+            TestUtils.AreEqual(663891101u, Random.WangHash(1u));
+            TestUtils.AreEqual(3329832309u, Random.WangHash(2u));
+            TestUtils.AreEqual(2278584254u, Random.WangHash(3u));
+            TestUtils.AreEqual(3427349084u, Random.WangHash(4u));
+            TestUtils.AreEqual(3322605197u, Random.WangHash(5u));
+            TestUtils.AreEqual(1902946834u, Random.WangHash(6u));
+            TestUtils.AreEqual(851741419u, Random.WangHash(7u));
+            TestUtils.AreEqual(0u, Random.WangHash(61u));
+
+            unchecked
+            {
+                // Random.CreateFromIndex() takes zero as a valid input and makes uint.MaxValue invalid
+                // so check that we can make uint.MaxValue hash to zero.
+                TestUtils.AreEqual(0u, Random.WangHash(uint.MaxValue + 62u));
+            }
+        }
     }
 }

--- a/src/Unity.Mathematics/random.cs
+++ b/src/Unity.Mathematics/random.cs
@@ -28,6 +28,45 @@ namespace Unity.Mathematics
         }
 
         /// <summary>
+        /// Constructs a <see cref="Random"/> instance with a hashed seed.
+        /// </summary>
+        /// <remarks>
+        /// Use this function when you expect to create several Random instances from consecutive or
+        /// very similar seeds.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// for (uint i = 0; i &lt; 4096; ++i)
+        /// {
+        ///     Random rand = Random.CreateFromHashedSeed(i);
+        ///
+        ///     // Random numbers drawn from loop iteration j should be very different
+        ///     // from every other loop iteration.
+        ///     rand.NextUInt();
+        /// }
+        /// </code>
+        /// </example>
+        /// <param name="seed_to_hash">A seed that will be hashed for Random creation.</param>
+        /// <param name="backup_nonzero_seed">In the event that <paramref name="seed_to_hash"/> hashes to zero, then the <see cref="Random"/> constructor will be called with this backup value as the seed instead.  No hashing is performed on the backup and it must be non-zero.</param>
+        /// <returns><see cref="Random"/> created from hashed seed.  If the seed hashes to zero, then the backup seed is used without hashing it.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Random CreateFromHashedSeed(uint seed_to_hash, uint backup_nonzero_seed = 1u)
+        {
+            // Wang hash: this has the property that none of the outputs will
+            // collide with each other, which is important for the purposes of
+            // seeding a random number generator.  This was verified empirically.
+            seed_to_hash = (seed_to_hash ^ 61u) ^ (seed_to_hash >> 16);
+            seed_to_hash *= 9u;
+            seed_to_hash = seed_to_hash ^ (seed_to_hash >> 4);
+            seed_to_hash *= 0x27d4eb2du;
+            seed_to_hash = seed_to_hash ^ (seed_to_hash >> 15);
+
+            // Random cannot accept zero as the seed, but the hashing process could generate zero
+            // so guard against that possibility.
+            return new Random(seed_to_hash != 0u ? seed_to_hash : backup_nonzero_seed);
+        }
+
+        /// <summary>
         /// Initialized the state of the Random instance with a given seed value. The seed must be non-zero.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Unity.Mathematics/random.cs
+++ b/src/Unity.Mathematics/random.cs
@@ -52,22 +52,26 @@ namespace Unity.Mathematics
         {
             CheckIndexForHash(index);
 
-            // Wang hash (below) will hash 61 to zero so choose a different index to hash to zero.
-            // We want uint.MaxValue to hash to zero so offset the index to (Picard voice) Make It So.
-            index += 62u;
+            // Wang hash will hash 61 to zero but we want uint.MaxValue to hash to zero.  To make this happen
+            // we must offset by 62.
+            return new Random(WangHash(index + 62u));
+        }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static uint WangHash(uint n)
+        {
             // https://gist.github.com/badboy/6267743#hash-function-construction-principles
             // Wang hash: this has the property that none of the outputs will
             // collide with each other, which is important for the purposes of
             // seeding a random number generator.  This was verified empirically
             // by checking all 2^32 uints.
-            index = (index ^ 61u) ^ (index >> 16);
-            index *= 9u;
-            index = index ^ (index >> 4);
-            index *= 0x27d4eb2du;
-            index = index ^ (index >> 15);
+            n = (n ^ 61u) ^ (n >> 16);
+            n *= 9u;
+            n = n ^ (n >> 4);
+            n *= 0x27d4eb2du;
+            n = n ^ (n >> 15);
 
-            return new Random(index);
+            return n;
         }
 
         /// <summary>


### PR DESCRIPTION
Random.CreateFromIndex() is intended to be used when multiple
instances of Random need to be created from loop indices.  The
hashing helps to ensure that the Random state is very different for
each index and reduces the chance that the numbers drawn from those
Random instances are similar.