### PR TITLE
Use package-ci images for upm-ci commands

### DIFF
--- a/.yamato/expectations/upm-ci.unfolded.yaml
+++ b/.yamato/expectations/upm-ci.unfolded.yaml
@@ -69,7 +69,6 @@ publish_ci:
 run_tests_on_mono_macOS: 
   name: Tests NUnit on macOS
   agent: 
-    name: macOS
     flavor: m1.mac
     image: burst/burst_mac:stable
     type: Unity::VM::osx
@@ -80,7 +79,6 @@ run_tests_on_mono_macOS:
 run_tests_on_mono_windows: 
   name: Tests NUnit on windows
   agent: 
-    name: windows
     flavor: b1.large
     image: sdet/burst-devimage:stable
     type: Unity::VM
@@ -92,7 +90,6 @@ run_tests_on_mono_windows:
 validate_package_linux_2018.4: 
   name: Validate package linux 2018.4
   agent: 
-    name: linux
     flavor: b1.large
     image: package-ci/ubuntu:stable
     type: Unity::VM
@@ -105,15 +102,14 @@ validate_package_linux_2018.4:
         - upm-ci~/**/*
   commands:
     - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
-    - DISPLAY=:0.0 upm-ci package pack --package-path src/
-    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2018.4
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2018.4
   dependencies:
     - .yamato/upm-ci.yml#run_tests_on_mono_windows
     - .yamato/upm-ci.yml#run_tests_on_mono_macOS
 validate_package_linux_2019.2: 
   name: Validate package linux 2019.2
   agent: 
-    name: linux
     flavor: b1.large
     image: package-ci/ubuntu:stable
     type: Unity::VM
@@ -126,15 +122,14 @@ validate_package_linux_2019.2:
         - upm-ci~/**/*
   commands:
     - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
-    - DISPLAY=:0.0 upm-ci package pack --package-path src/
-    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2019.2
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.2
   dependencies:
     - .yamato/upm-ci.yml#run_tests_on_mono_windows
     - .yamato/upm-ci.yml#run_tests_on_mono_macOS
 validate_package_linux_2019.3: 
   name: Validate package linux 2019.3
   agent: 
-    name: linux
     flavor: b1.large
     image: package-ci/ubuntu:stable
     type: Unity::VM
@@ -147,15 +142,14 @@ validate_package_linux_2019.3:
         - upm-ci~/**/*
   commands:
     - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
-    - DISPLAY=:0.0 upm-ci package pack --package-path src/
-    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2019.3
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.3
   dependencies:
     - .yamato/upm-ci.yml#run_tests_on_mono_windows
     - .yamato/upm-ci.yml#run_tests_on_mono_macOS
 validate_package_linux_trunk: 
   name: Validate package linux trunk
   agent: 
-    name: linux
     flavor: b1.large
     image: package-ci/ubuntu:stable
     type: Unity::VM
@@ -168,17 +162,16 @@ validate_package_linux_trunk:
         - upm-ci~/**/*
   commands:
     - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
-    - DISPLAY=:0.0 upm-ci package pack --package-path src/
-    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version trunk
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version trunk
   dependencies:
     - .yamato/upm-ci.yml#run_tests_on_mono_windows
     - .yamato/upm-ci.yml#run_tests_on_mono_macOS
 validate_package_macOS_2018.4: 
   name: Validate package macOS 2018.4
   agent: 
-    name: macOS
     flavor: m1.mac
-    image: burst/burst_mac:stable
+    image: package-ci/mac:stable
     type: Unity::VM::osx
   artifacts: 
     packages_macOS_2018.4: 
@@ -197,9 +190,8 @@ validate_package_macOS_2018.4:
 validate_package_macOS_2019.2: 
   name: Validate package macOS 2019.2
   agent: 
-    name: macOS
     flavor: m1.mac
-    image: burst/burst_mac:stable
+    image: package-ci/mac:stable
     type: Unity::VM::osx
   artifacts: 
     packages_macOS_2019.2: 
@@ -218,9 +210,8 @@ validate_package_macOS_2019.2:
 validate_package_macOS_2019.3: 
   name: Validate package macOS 2019.3
   agent: 
-    name: macOS
     flavor: m1.mac
-    image: burst/burst_mac:stable
+    image: package-ci/mac:stable
     type: Unity::VM::osx
   artifacts: 
     packages_macOS_2019.3: 
@@ -239,9 +230,8 @@ validate_package_macOS_2019.3:
 validate_package_macOS_trunk: 
   name: Validate package macOS trunk
   agent: 
-    name: macOS
     flavor: m1.mac
-    image: burst/burst_mac:stable
+    image: package-ci/mac:stable
     type: Unity::VM::osx
   artifacts: 
     packages_macOS_trunk: 
@@ -260,7 +250,6 @@ validate_package_macOS_trunk:
 validate_package_minimal: 
   name: Validate Package Linux Minimal
   agent: 
-    name: linux
     flavor: b1.large
     image: package-ci/ubuntu:stable
     type: Unity::VM
@@ -270,17 +259,16 @@ validate_package_minimal:
         - upm-ci~/packages/**/*
   commands:
     - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
-    - DISPLAY=:0.0 upm-ci package pack --package-path src/
-    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2019.1
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.1
   dependencies:
     - .yamato/upm-ci.yml#run_tests_on_mono_windows
     - .yamato/upm-ci.yml#run_tests_on_mono_macOS
 validate_package_windows_2018.4: 
   name: Validate package windows 2018.4
   agent: 
-    name: windows
-    flavor: b1.large
-    image: sdet/burst-devimage:stable
+    flavor: m1.large
+    image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 
     packages_windows_2018.4: 
@@ -299,9 +287,8 @@ validate_package_windows_2018.4:
 validate_package_windows_2019.2: 
   name: Validate package windows 2019.2
   agent: 
-    name: windows
-    flavor: b1.large
-    image: sdet/burst-devimage:stable
+    flavor: m1.large
+    image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 
     packages_windows_2019.2: 
@@ -320,9 +307,8 @@ validate_package_windows_2019.2:
 validate_package_windows_2019.3: 
   name: Validate package windows 2019.3
   agent: 
-    name: windows
-    flavor: b1.large
-    image: sdet/burst-devimage:stable
+    flavor: m1.large
+    image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 
     packages_windows_2019.3: 
@@ -341,9 +327,8 @@ validate_package_windows_2019.3:
 validate_package_windows_trunk: 
   name: Validate package windows trunk
   agent: 
-    name: windows
-    flavor: b1.large
-    image: sdet/burst-devimage:stable
+    flavor: m1.large
+    image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 
     packages_windows_trunk: 

--- a/.yamato/expectations/upm-ci.unfolded.yaml
+++ b/.yamato/expectations/upm-ci.unfolded.yaml
@@ -1,0 +1,361 @@
+
+commit_ci: 
+  name: all CI pipeline
+  dependencies:
+    - .yamato/upm-ci.yml#validate_package_minimal
+  triggers: 
+    branches: 
+      only:
+        - /.*/
+nightly_ci: 
+  name: all Nightly Pipeline
+  dependencies:
+    - .yamato/upm-ci.yml#validate_package_windows_2018.4
+    - .yamato/upm-ci.yml#validate_package_windows_2019.2
+    - .yamato/upm-ci.yml#validate_package_windows_2019.3
+    - .yamato/upm-ci.yml#validate_package_windows_trunk
+    - .yamato/upm-ci.yml#validate_package_linux_2018.4
+    - .yamato/upm-ci.yml#validate_package_linux_2019.2
+    - .yamato/upm-ci.yml#validate_package_linux_2019.3
+    - .yamato/upm-ci.yml#validate_package_linux_trunk
+    - .yamato/upm-ci.yml#validate_package_macOS_2018.4
+    - .yamato/upm-ci.yml#validate_package_macOS_2019.2
+    - .yamato/upm-ci.yml#validate_package_macOS_2019.3
+    - .yamato/upm-ci.yml#validate_package_macOS_trunk
+  triggers: 
+    recurring:
+      - branch: master
+        frequency: daily
+promote: 
+  name: Promote
+  agent: 
+    flavor: m1.large
+    image: package-ci/win10:stable
+    type: Unity::VM
+  artifacts: 
+    packages: 
+      paths:
+        - upm-ci~/packages/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package promote --package-path src/
+  dependencies:
+    - .yamato/upm-ci.yml#publish
+  variables: 
+    UPMCI_PROMOTION: 1
+publish: 
+  name: Publish
+  agent: 
+    flavor: m1.large
+    image: package-ci/win10:stable
+    type: Unity::VM
+  artifacts: 
+    packages: 
+      paths:
+        - upm-ci~/packages/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package publish --package-path src/
+  dependencies:
+    - .yamato/upm-ci.yml#validate_package_minimal
+publish_ci: 
+  name: all Publish Pipeline
+  dependencies:
+    - .yamato/upm-ci.yml#publish
+  triggers: 
+    tags: 
+      only:
+        - /^\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+run_tests_on_mono_macOS: 
+  name: Tests NUnit on macOS
+  agent: 
+    name: macOS
+    flavor: m1.mac
+    image: burst/burst_mac:stable
+    type: Unity::VM::osx
+  commands:
+    - nuget restore src
+    - msbuild src/Unity.Mathematics.sln
+    - mono src/packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe src/Tests/bin/Debug/Unity.Mathematics.Tests.dll --process=single
+run_tests_on_mono_windows: 
+  name: Tests NUnit on windows
+  agent: 
+    name: windows
+    flavor: b1.large
+    image: sdet/burst-devimage:stable
+    type: Unity::VM
+  commands:
+    - choco install nuget.commandline
+    - nuget restore src
+    - msbuild src/Unity.Mathematics.sln
+    - mono src/packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe src/Tests/bin/Debug/Unity.Mathematics.Tests.dll --process=single
+validate_package_linux_2018.4: 
+  name: Validate package linux 2018.4
+  agent: 
+    name: linux
+    flavor: b1.large
+    image: package-ci/ubuntu:stable
+    type: Unity::VM
+  artifacts: 
+    packages_linux_2018.4: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_linux_2018.4: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - DISPLAY=:0.0 upm-ci package pack --package-path src/
+    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2018.4
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_linux_2019.2: 
+  name: Validate package linux 2019.2
+  agent: 
+    name: linux
+    flavor: b1.large
+    image: package-ci/ubuntu:stable
+    type: Unity::VM
+  artifacts: 
+    packages_linux_2019.2: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_linux_2019.2: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - DISPLAY=:0.0 upm-ci package pack --package-path src/
+    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2019.2
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_linux_2019.3: 
+  name: Validate package linux 2019.3
+  agent: 
+    name: linux
+    flavor: b1.large
+    image: package-ci/ubuntu:stable
+    type: Unity::VM
+  artifacts: 
+    packages_linux_2019.3: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_linux_2019.3: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - DISPLAY=:0.0 upm-ci package pack --package-path src/
+    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2019.3
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_linux_trunk: 
+  name: Validate package linux trunk
+  agent: 
+    name: linux
+    flavor: b1.large
+    image: package-ci/ubuntu:stable
+    type: Unity::VM
+  artifacts: 
+    packages_linux_trunk: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_linux_trunk: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - DISPLAY=:0.0 upm-ci package pack --package-path src/
+    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version trunk
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_macOS_2018.4: 
+  name: Validate package macOS 2018.4
+  agent: 
+    name: macOS
+    flavor: m1.mac
+    image: burst/burst_mac:stable
+    type: Unity::VM::osx
+  artifacts: 
+    packages_macOS_2018.4: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_macOS_2018.4: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2018.4
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_macOS_2019.2: 
+  name: Validate package macOS 2019.2
+  agent: 
+    name: macOS
+    flavor: m1.mac
+    image: burst/burst_mac:stable
+    type: Unity::VM::osx
+  artifacts: 
+    packages_macOS_2019.2: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_macOS_2019.2: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.2
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_macOS_2019.3: 
+  name: Validate package macOS 2019.3
+  agent: 
+    name: macOS
+    flavor: m1.mac
+    image: burst/burst_mac:stable
+    type: Unity::VM::osx
+  artifacts: 
+    packages_macOS_2019.3: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_macOS_2019.3: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.3
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_macOS_trunk: 
+  name: Validate package macOS trunk
+  agent: 
+    name: macOS
+    flavor: m1.mac
+    image: burst/burst_mac:stable
+    type: Unity::VM::osx
+  artifacts: 
+    packages_macOS_trunk: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_macOS_trunk: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version trunk
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_minimal: 
+  name: Validate Package Linux Minimal
+  agent: 
+    name: linux
+    flavor: b1.large
+    image: package-ci/ubuntu:stable
+    type: Unity::VM
+  artifacts: 
+    packages: 
+      paths:
+        - upm-ci~/packages/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - DISPLAY=:0.0 upm-ci package pack --package-path src/
+    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2019.1
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_windows_2018.4: 
+  name: Validate package windows 2018.4
+  agent: 
+    name: windows
+    flavor: b1.large
+    image: sdet/burst-devimage:stable
+    type: Unity::VM
+  artifacts: 
+    packages_windows_2018.4: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_windows_2018.4: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2018.4
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_windows_2019.2: 
+  name: Validate package windows 2019.2
+  agent: 
+    name: windows
+    flavor: b1.large
+    image: sdet/burst-devimage:stable
+    type: Unity::VM
+  artifacts: 
+    packages_windows_2019.2: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_windows_2019.2: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.2
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_windows_2019.3: 
+  name: Validate package windows 2019.3
+  agent: 
+    name: windows
+    flavor: b1.large
+    image: sdet/burst-devimage:stable
+    type: Unity::VM
+  artifacts: 
+    packages_windows_2019.3: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_windows_2019.3: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.3
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS
+validate_package_windows_trunk: 
+  name: Validate package windows trunk
+  agent: 
+    name: windows
+    flavor: b1.large
+    image: sdet/burst-devimage:stable
+    type: Unity::VM
+  artifacts: 
+    packages_windows_trunk: 
+      paths:
+        - upm-ci~/packages/**/*
+    results_windows_trunk: 
+      paths:
+        - upm-ci~/**/*
+  commands:
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version trunk
+  dependencies:
+    - .yamato/upm-ci.yml#run_tests_on_mono_windows
+    - .yamato/upm-ci.yml#run_tests_on_mono_macOS

--- a/.yamato/expectations/upm-ci.unfolded.yaml
+++ b/.yamato/expectations/upm-ci.unfolded.yaml
@@ -267,7 +267,7 @@ validate_package_minimal:
 validate_package_windows_2018.4: 
   name: Validate package windows 2018.4
   agent: 
-    flavor: m1.large
+    flavor: b1.large
     image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 
@@ -287,7 +287,7 @@ validate_package_windows_2018.4:
 validate_package_windows_2019.2: 
   name: Validate package windows 2019.2
   agent: 
-    flavor: m1.large
+    flavor: b1.large
     image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 
@@ -307,7 +307,7 @@ validate_package_windows_2019.2:
 validate_package_windows_2019.3: 
   name: Validate package windows 2019.3
   agent: 
-    flavor: m1.large
+    flavor: b1.large
     image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 
@@ -327,7 +327,7 @@ validate_package_windows_2019.3:
 validate_package_windows_trunk: 
   name: Validate package windows trunk
   agent: 
-    flavor: m1.large
+    flavor: b1.large
     image: package-ci/win10:stable
     type: Unity::VM
   artifacts: 

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -3,21 +3,28 @@ build_platforms:
     type: Unity::VM
     image: sdet/burst-devimage:stable
     flavor: b1.large
-    npm_cmd: "npm"
-    upm_cmd: "upm-ci"
   - name: linux
     image: package-ci/ubuntu:stable
     type: Unity::VM
     flavor: b1.large
-    npm_cmd: "npm"
-    upm_cmd: "DISPLAY=:0.0 upm-ci"
   - name: macOS
     image: burst/burst_mac:stable
     type: Unity::VM::osx
     flavor: m1.mac
-    npm_cmd: "npm"
-    upm_cmd: "upm-ci"
 
+upmci_platforms:
+  - name: windows
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: m1.large
+  - name: linux
+    image: package-ci/ubuntu:stable
+    type: Unity::VM
+    flavor: b1.large
+  - name: macOS
+    image: package-ci/mac:stable
+    type: Unity::VM::osx
+    flavor: m1.mac
 
 editor_versions:
   - version: "2018.4"
@@ -31,7 +38,6 @@ editor_versions:
 run_tests_on_mono_{{platform.name}}:
   name: Tests NUnit on {{platform.name}}
   agent:
-      name: {{platform.name}}
       type: {{platform.type}}
       image: {{platform.image}}
       flavor: {{platform.flavor}}
@@ -48,14 +54,13 @@ run_tests_on_mono_{{platform.name}}:
 validate_package_minimal:
   name: Validate Package Linux Minimal
   agent:
-    name: linux
     image: package-ci/ubuntu:stable
     type: Unity::VM
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
-    - DISPLAY=:0.0 upm-ci package pack --package-path src/
-    - DISPLAY=:0.0 upm-ci package test --package-path src/ --unity-version 2019.1
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version 2019.1
   artifacts:
     packages:
       paths:
@@ -67,19 +72,18 @@ validate_package_minimal:
     {% endunless %}
     {% endfor %}
 
-  {% for platform in build_platforms %}
+  {% for platform in upmci_platforms %}
   {% for editor in editor_versions %}
 validate_package_{{platform.name}}_{{editor.version}}:
   name: Validate package {{platform.name}} {{editor.version}}
   agent:
-    name: {{platform.name}}
     image: {{platform.image}}
     type: {{platform.type}}
     flavor: {{platform.flavor}}
   commands:
-    - {{platform.npm_cmd}} install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
-    - {{platform.upm_cmd}} package pack --package-path src/
-    - {{platform.upm_cmd}} package test --package-path src/ --unity-version {{ editor.version }}
+    - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
+    - upm-ci package pack --package-path src/
+    - upm-ci package test --package-path src/ --unity-version {{ editor.version }}
   artifacts:
     packages_{{platform.name}}_{{editor.version}}:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -16,7 +16,7 @@ upmci_platforms:
   - name: windows
     type: Unity::VM
     image: package-ci/win10:stable
-    flavor: m1.large
+    flavor: b1.large
   - name: linux
     image: package-ci/ubuntu:stable
     type: Unity::VM


### PR DESCRIPTION
To solve `upm-ci` related to outdated NodeJS in the burst images.

* Cleanup unnecesssary `upm_cmd` and `npm_cmd` variables
* Remove unnecessary DISPLAY=:0.0 environment

The diff https://github.com/Unity-Technologies/Unity.Mathematics/pull/158/commits/8219912b84abfd198902f5e2ef82b34c2ae55d29 shows the actual changed behavior.