### PR TITLE
Tag Unity.Mathematics types with new IL2CPP attribute.

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Added `[Il2CppEagerStaticClassConstruction]` to Unity.Mathematics types to run static constructors at startup. This improves IL2CPP performance slightly for types that have static constructors.
 * Added `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to many static functions to improve IL2CPP performance.
 * Added `compress()` that accepts a `float4` and `uint4`.
 * Added `math.project()` and `math.projectsafe()` for vector projection.

--- a/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
+++ b/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
@@ -506,6 +506,7 @@ namespace Unity.Mathematics.Mathematics.CodeGen
                 str.Append("using System.Runtime.InteropServices;\n");  // for MarshalAs
             if (m_Columns == 1)
                 str.Append("using System.Diagnostics;\n");   // for DebuggerTypeProxy
+            str.Append("using Unity.IL2CPP.CompilerServices;\n");
             str.Append("\n");
             str.Append("#pragma warning disable 0660, 0661\n\n");
             str.Append("namespace Unity.Mathematics\n");
@@ -514,6 +515,7 @@ namespace Unity.Mathematics.Mathematics.CodeGen
             if (m_Columns == 1)
                 str.AppendFormat("\t[DebuggerTypeProxy(typeof({0}.DebuggerProxy))]\n", m_TypeName);
             str.Append("\t[System.Serializable]\n");
+            str.Append("\t[Il2CppEagerStaticClassConstruction]\n");
             str.AppendFormat("\tpublic partial struct {0} : System.IEquatable<{0}>", m_TypeName);
             if (m_BaseType != "bool")
                 str.Append(", IFormattable");

--- a/src/Unity.Mathematics/Geometry/MinMaxAABB.cs
+++ b/src/Unity.Mathematics/Geometry/MinMaxAABB.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 using static Unity.Mathematics.math;
 
 namespace Unity.Mathematics.Geometry
@@ -14,6 +15,7 @@ namespace Unity.Mathematics.Geometry
     /// are very cheap to construct and perform overlap tests with them.
     /// </remarks>
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     internal struct MinMaxAABB : IEquatable<MinMaxAABB>
     {
         /// <summary>

--- a/src/Unity.Mathematics/Geometry/Plane.cs
+++ b/src/Unity.Mathematics/Geometry/Plane.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 namespace Unity.Mathematics.Geometry
 {
@@ -13,6 +14,7 @@ namespace Unity.Mathematics.Geometry
     /// </remarks>
     [DebuggerDisplay("{Normal}, {Distance}")]
     [Serializable]
+    [Il2CppEagerStaticClassConstruction]
     internal struct Plane
     {
         /// <summary>
@@ -122,7 +124,7 @@ namespace Unity.Mathematics.Geometry
         /// </summary>
         /// <remarks>
         /// It is assumed that the normal is unit length.  If you set a new plane such that Ax + By + Cz + Dw = 0 but
-        /// (A, B, C) is not unit length, then you must normalize the plane by calling <see cref="Normalize(Unity.Mathematics.Extras.Plane)"/>.
+        /// (A, B, C) is not unit length, then you must normalize the plane by calling <see cref="Normalize(Plane)"/>.
         /// </remarks>
         public float3 Normal
         {
@@ -135,7 +137,7 @@ namespace Unity.Mathematics.Geometry
         /// </summary>
         /// <remarks>
         /// It is assumed that the normal is unit length.  If you set a new plane such that Ax + By + Cz + Dw = 0 but
-        /// (A, B, C) is not unit length, then you must normalize the plane by calling <see cref="Normalize(Unity.Mathematics.Extras.Plane)"/>.
+        /// (A, B, C) is not unit length, then you must normalize the plane by calling <see cref="Normalize(Plane)"/>.
         /// </remarks>
         public float Distance
         {

--- a/src/Unity.Mathematics/Il2CppEagerStaticClassConstructionAttribute.cs
+++ b/src/Unity.Mathematics/Il2CppEagerStaticClassConstructionAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Unity.IL2CPP.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
+    public class Il2CppEagerStaticClassConstructionAttribute : Attribute
+    {
+    }
+}

--- a/src/Unity.Mathematics/Il2CppEagerStaticClassConstructionAttribute.cs.meta
+++ b/src/Unity.Mathematics/Il2CppEagerStaticClassConstructionAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c7ef86a2cddb4254810c84d4f6e6618
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Unity.Mathematics/Noise/common.cs
+++ b/src/Unity.Mathematics/Noise/common.cs
@@ -1,7 +1,9 @@
+using Unity.IL2CPP.CompilerServices;
 using static Unity.Mathematics.math;
 
 namespace Unity.Mathematics
 {
+    [Il2CppEagerStaticClassConstruction]
     public static partial class noise
     {
         // Modulo 289 without a division (only multiplications)

--- a/src/Unity.Mathematics/Unity.Mathematics.csproj
+++ b/src/Unity.Mathematics/Unity.Mathematics.csproj
@@ -105,6 +105,7 @@
     <Compile Include="half2.gen.cs" />
     <Compile Include="half3.gen.cs" />
     <Compile Include="half4.gen.cs" />
+    <Compile Include="Il2CppEagerStaticClassConstructionAttribute.cs" />
     <Compile Include="int2x2.gen.cs" />
     <Compile Include="int2x3.gen.cs" />
     <Compile Include="int2x4.gen.cs" />

--- a/src/Unity.Mathematics/bool2.gen.cs
+++ b/src/Unity.Mathematics/bool2.gen.cs
@@ -10,6 +10,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -17,6 +18,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(bool2.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool2 : System.IEquatable<bool2>
     {
         [MarshalAs(UnmanagedType.U1)]

--- a/src/Unity.Mathematics/bool2x2.gen.cs
+++ b/src/Unity.Mathematics/bool2x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool2x2 : System.IEquatable<bool2x2>
     {
         public bool2 c0;

--- a/src/Unity.Mathematics/bool2x3.gen.cs
+++ b/src/Unity.Mathematics/bool2x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool2x3 : System.IEquatable<bool2x3>
     {
         public bool2 c0;

--- a/src/Unity.Mathematics/bool2x4.gen.cs
+++ b/src/Unity.Mathematics/bool2x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool2x4 : System.IEquatable<bool2x4>
     {
         public bool2 c0;

--- a/src/Unity.Mathematics/bool3.gen.cs
+++ b/src/Unity.Mathematics/bool3.gen.cs
@@ -10,6 +10,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -17,6 +18,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(bool3.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool3 : System.IEquatable<bool3>
     {
         [MarshalAs(UnmanagedType.U1)]

--- a/src/Unity.Mathematics/bool3x2.gen.cs
+++ b/src/Unity.Mathematics/bool3x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool3x2 : System.IEquatable<bool3x2>
     {
         public bool3 c0;

--- a/src/Unity.Mathematics/bool3x3.gen.cs
+++ b/src/Unity.Mathematics/bool3x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool3x3 : System.IEquatable<bool3x3>
     {
         public bool3 c0;

--- a/src/Unity.Mathematics/bool3x4.gen.cs
+++ b/src/Unity.Mathematics/bool3x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool3x4 : System.IEquatable<bool3x4>
     {
         public bool3 c0;

--- a/src/Unity.Mathematics/bool4.gen.cs
+++ b/src/Unity.Mathematics/bool4.gen.cs
@@ -10,6 +10,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -17,6 +18,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(bool4.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool4 : System.IEquatable<bool4>
     {
         [MarshalAs(UnmanagedType.U1)]

--- a/src/Unity.Mathematics/bool4x2.gen.cs
+++ b/src/Unity.Mathematics/bool4x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool4x2 : System.IEquatable<bool4x2>
     {
         public bool4 c0;

--- a/src/Unity.Mathematics/bool4x3.gen.cs
+++ b/src/Unity.Mathematics/bool4x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool4x3 : System.IEquatable<bool4x3>
     {
         public bool4 c0;

--- a/src/Unity.Mathematics/bool4x4.gen.cs
+++ b/src/Unity.Mathematics/bool4x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct bool4x4 : System.IEquatable<bool4x4>
     {
         public bool4 c0;

--- a/src/Unity.Mathematics/double2.gen.cs
+++ b/src/Unity.Mathematics/double2.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(double2.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double2 : System.IEquatable<double2>, IFormattable
     {
         public double x;

--- a/src/Unity.Mathematics/double2x2.gen.cs
+++ b/src/Unity.Mathematics/double2x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double2x2 : System.IEquatable<double2x2>, IFormattable
     {
         public double2 c0;

--- a/src/Unity.Mathematics/double2x3.gen.cs
+++ b/src/Unity.Mathematics/double2x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double2x3 : System.IEquatable<double2x3>, IFormattable
     {
         public double2 c0;

--- a/src/Unity.Mathematics/double2x4.gen.cs
+++ b/src/Unity.Mathematics/double2x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double2x4 : System.IEquatable<double2x4>, IFormattable
     {
         public double2 c0;

--- a/src/Unity.Mathematics/double3.gen.cs
+++ b/src/Unity.Mathematics/double3.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(double3.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double3 : System.IEquatable<double3>, IFormattable
     {
         public double x;

--- a/src/Unity.Mathematics/double3x2.gen.cs
+++ b/src/Unity.Mathematics/double3x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double3x2 : System.IEquatable<double3x2>, IFormattable
     {
         public double3 c0;

--- a/src/Unity.Mathematics/double3x3.gen.cs
+++ b/src/Unity.Mathematics/double3x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double3x3 : System.IEquatable<double3x3>, IFormattable
     {
         public double3 c0;

--- a/src/Unity.Mathematics/double3x4.gen.cs
+++ b/src/Unity.Mathematics/double3x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double3x4 : System.IEquatable<double3x4>, IFormattable
     {
         public double3 c0;

--- a/src/Unity.Mathematics/double4.gen.cs
+++ b/src/Unity.Mathematics/double4.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(double4.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double4 : System.IEquatable<double4>, IFormattable
     {
         public double x;

--- a/src/Unity.Mathematics/double4x2.gen.cs
+++ b/src/Unity.Mathematics/double4x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double4x2 : System.IEquatable<double4x2>, IFormattable
     {
         public double4 c0;

--- a/src/Unity.Mathematics/double4x3.gen.cs
+++ b/src/Unity.Mathematics/double4x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double4x3 : System.IEquatable<double4x3>, IFormattable
     {
         public double4 c0;

--- a/src/Unity.Mathematics/double4x4.gen.cs
+++ b/src/Unity.Mathematics/double4x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct double4x4 : System.IEquatable<double4x4>, IFormattable
     {
         public double4 c0;

--- a/src/Unity.Mathematics/float2.gen.cs
+++ b/src/Unity.Mathematics/float2.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(float2.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float2 : System.IEquatable<float2>, IFormattable
     {
         public float x;

--- a/src/Unity.Mathematics/float2x2.gen.cs
+++ b/src/Unity.Mathematics/float2x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float2x2 : System.IEquatable<float2x2>, IFormattable
     {
         public float2 c0;

--- a/src/Unity.Mathematics/float2x3.gen.cs
+++ b/src/Unity.Mathematics/float2x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float2x3 : System.IEquatable<float2x3>, IFormattable
     {
         public float2 c0;

--- a/src/Unity.Mathematics/float2x4.gen.cs
+++ b/src/Unity.Mathematics/float2x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float2x4 : System.IEquatable<float2x4>, IFormattable
     {
         public float2 c0;

--- a/src/Unity.Mathematics/float3.gen.cs
+++ b/src/Unity.Mathematics/float3.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(float3.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float3 : System.IEquatable<float3>, IFormattable
     {
         public float x;

--- a/src/Unity.Mathematics/float3x2.gen.cs
+++ b/src/Unity.Mathematics/float3x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float3x2 : System.IEquatable<float3x2>, IFormattable
     {
         public float3 c0;

--- a/src/Unity.Mathematics/float3x3.gen.cs
+++ b/src/Unity.Mathematics/float3x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float3x3 : System.IEquatable<float3x3>, IFormattable
     {
         public float3 c0;

--- a/src/Unity.Mathematics/float3x4.gen.cs
+++ b/src/Unity.Mathematics/float3x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float3x4 : System.IEquatable<float3x4>, IFormattable
     {
         public float3 c0;

--- a/src/Unity.Mathematics/float4.gen.cs
+++ b/src/Unity.Mathematics/float4.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(float4.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float4 : System.IEquatable<float4>, IFormattable
     {
         public float x;

--- a/src/Unity.Mathematics/float4x2.gen.cs
+++ b/src/Unity.Mathematics/float4x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float4x2 : System.IEquatable<float4x2>, IFormattable
     {
         public float4 c0;

--- a/src/Unity.Mathematics/float4x3.gen.cs
+++ b/src/Unity.Mathematics/float4x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float4x3 : System.IEquatable<float4x3>, IFormattable
     {
         public float4 c0;

--- a/src/Unity.Mathematics/float4x4.gen.cs
+++ b/src/Unity.Mathematics/float4x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct float4x4 : System.IEquatable<float4x4>, IFormattable
     {
         public float4 c0;

--- a/src/Unity.Mathematics/half.cs
+++ b/src/Unity.Mathematics/half.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 namespace Unity.Mathematics
 {
+    [Il2CppEagerStaticClassConstruction]
     [Serializable]
     public struct half : System.IEquatable<half>, IFormattable
     {

--- a/src/Unity.Mathematics/half2.gen.cs
+++ b/src/Unity.Mathematics/half2.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(half2.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct half2 : System.IEquatable<half2>, IFormattable
     {
         public half x;

--- a/src/Unity.Mathematics/half3.gen.cs
+++ b/src/Unity.Mathematics/half3.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(half3.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct half3 : System.IEquatable<half3>, IFormattable
     {
         public half x;

--- a/src/Unity.Mathematics/half4.gen.cs
+++ b/src/Unity.Mathematics/half4.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(half4.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct half4 : System.IEquatable<half4>, IFormattable
     {
         public half x;

--- a/src/Unity.Mathematics/int2.gen.cs
+++ b/src/Unity.Mathematics/int2.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(int2.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int2 : System.IEquatable<int2>, IFormattable
     {
         public int x;

--- a/src/Unity.Mathematics/int2x2.gen.cs
+++ b/src/Unity.Mathematics/int2x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int2x2 : System.IEquatable<int2x2>, IFormattable
     {
         public int2 c0;

--- a/src/Unity.Mathematics/int2x3.gen.cs
+++ b/src/Unity.Mathematics/int2x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int2x3 : System.IEquatable<int2x3>, IFormattable
     {
         public int2 c0;

--- a/src/Unity.Mathematics/int2x4.gen.cs
+++ b/src/Unity.Mathematics/int2x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int2x4 : System.IEquatable<int2x4>, IFormattable
     {
         public int2 c0;

--- a/src/Unity.Mathematics/int3.gen.cs
+++ b/src/Unity.Mathematics/int3.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(int3.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int3 : System.IEquatable<int3>, IFormattable
     {
         public int x;

--- a/src/Unity.Mathematics/int3x2.gen.cs
+++ b/src/Unity.Mathematics/int3x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int3x2 : System.IEquatable<int3x2>, IFormattable
     {
         public int3 c0;

--- a/src/Unity.Mathematics/int3x3.gen.cs
+++ b/src/Unity.Mathematics/int3x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int3x3 : System.IEquatable<int3x3>, IFormattable
     {
         public int3 c0;

--- a/src/Unity.Mathematics/int3x4.gen.cs
+++ b/src/Unity.Mathematics/int3x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int3x4 : System.IEquatable<int3x4>, IFormattable
     {
         public int3 c0;

--- a/src/Unity.Mathematics/int4.gen.cs
+++ b/src/Unity.Mathematics/int4.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(int4.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int4 : System.IEquatable<int4>, IFormattable
     {
         public int x;

--- a/src/Unity.Mathematics/int4x2.gen.cs
+++ b/src/Unity.Mathematics/int4x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int4x2 : System.IEquatable<int4x2>, IFormattable
     {
         public int4 c0;

--- a/src/Unity.Mathematics/int4x3.gen.cs
+++ b/src/Unity.Mathematics/int4x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int4x3 : System.IEquatable<int4x3>, IFormattable
     {
         public int4 c0;

--- a/src/Unity.Mathematics/int4x4.gen.cs
+++ b/src/Unity.Mathematics/int4x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct int4x4 : System.IEquatable<int4x4>, IFormattable
     {
         public int4 c0;

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 namespace Unity.Mathematics
 {
+    [Il2CppEagerStaticClassConstruction]
     public static partial class math
     {
         /// <summary>Extrinsic rotation order. Specifies in which order rotations around the principal axes (x, y and z) are to be applied.</summary>
@@ -447,8 +449,8 @@ namespace Unity.Mathematics
         /// Checks if each component of the input is a power of two.
         /// </summary>
         /// <remarks>If a component of x is less than or equal to zero, then this function returns false in that component.</remarks>
-        /// <param name="x"><see cref="int2"/> input</param>
-        /// <returns><see cref="bool2"/> where true in a component indicates the same component in the input was a power of two.</returns>
+        /// <param name="x"><see cref="Mathematics.int2"/> input</param>
+        /// <returns><see cref="Mathematics.bool2"/> where true in a component indicates the same component in the input was a power of two.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool2 ispow2(int2 x)
         {
@@ -459,8 +461,8 @@ namespace Unity.Mathematics
         /// Checks if each component of the input is a power of two.
         /// </summary>
         /// <remarks>If a component of x is less than or equal to zero, then this function returns false in that component.</remarks>
-        /// <param name="x"><see cref="int3"/> input</param>
-        /// <returns><see cref="bool3"/> where true in a component indicates the same component in the input was a power of two.</returns>
+        /// <param name="x"><see cref="Mathematics.int3"/> input</param>
+        /// <returns><see cref="Mathematics.bool3"/> where true in a component indicates the same component in the input was a power of two.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool3 ispow2(int3 x)
         {
@@ -471,8 +473,8 @@ namespace Unity.Mathematics
         /// Checks if each component of the input is a power of two.
         /// </summary>
         /// <remarks>If a component of x is less than or equal to zero, then this function returns false in that component.</remarks>
-        /// <param name="x"><see cref="int4"/> input</param>
-        /// <returns><see cref="bool4"/> where true in a component indicates the same component in the input was a power of two.</returns>
+        /// <param name="x"><see cref="Mathematics.int4"/> input</param>
+        /// <returns><see cref="Mathematics.bool4"/> where true in a component indicates the same component in the input was a power of two.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool4 ispow2(int4 x)
         {
@@ -495,8 +497,8 @@ namespace Unity.Mathematics
         /// Checks if each component of the input is a power of two.
         /// </summary>
         /// <remarks>If a component of x is less than or equal to zero, then this function returns false in that component.</remarks>
-        /// <param name="x"><see cref="uint2"/> input</param>
-        /// <returns><see cref="bool2"/> where true in a component indicates the same component in the input was a power of two.</returns>
+        /// <param name="x"><see cref="Mathematics.uint2"/> input</param>
+        /// <returns><see cref="Mathematics.bool2"/> where true in a component indicates the same component in the input was a power of two.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool2 ispow2(uint2 x)
         {
@@ -507,8 +509,8 @@ namespace Unity.Mathematics
         /// Checks if each component of the input is a power of two.
         /// </summary>
         /// <remarks>If a component of x is less than or equal to zero, then this function returns false in that component.</remarks>
-        /// <param name="x"><see cref="uint3"/> input</param>
-        /// <returns><see cref="bool3"/> where true in a component indicates the same component in the input was a power of two.</returns>
+        /// <param name="x"><see cref="Mathematics.uint3"/> input</param>
+        /// <returns><see cref="Mathematics.bool3"/> where true in a component indicates the same component in the input was a power of two.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool3 ispow2(uint3 x)
         {
@@ -519,8 +521,8 @@ namespace Unity.Mathematics
         /// Checks if each component of the input is a power of two.
         /// </summary>
         /// <remarks>If a component of x is less than or equal to zero, then this function returns false in that component.</remarks>
-        /// <param name="x"><see cref="uint4"/> input</param>
-        /// <returns><see cref="bool4"/> where true in a component indicates the same component in the input was a power of two.</returns>
+        /// <param name="x"><see cref="Mathematics.uint4"/> input</param>
+        /// <returns><see cref="Mathematics.bool4"/> where true in a component indicates the same component in the input was a power of two.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool4 ispow2(uint4 x)
         {
@@ -3648,7 +3650,7 @@ namespace Unity.Mathematics
         /// <remarks>
         /// Components of x must be greater than 0, otherwise the result for that component is undefined.
         /// </remarks>
-        /// <param name="x"><see cref="int2"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.int2"/> to be used as input.</param>
         /// <returns>Componentwise ceiling of the base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int2 ceillog2(int2 x)
@@ -3662,7 +3664,7 @@ namespace Unity.Mathematics
         /// <remarks>
         /// Components of x must be greater than 0, otherwise the result for that component is undefined.
         /// </remarks>
-        /// <param name="x"><see cref="int3"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.int3"/> to be used as input.</param>
         /// <returns>Componentwise ceiling of the base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int3 ceillog2(int3 x)
@@ -3676,7 +3678,7 @@ namespace Unity.Mathematics
         /// <remarks>
         /// Components of x must be greater than 0, otherwise the result for that component is undefined.
         /// </remarks>
-        /// <param name="x"><see cref="int4"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.int4"/> to be used as input.</param>
         /// <returns>Componentwise ceiling of the base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int4 ceillog2(int4 x)
@@ -3704,7 +3706,7 @@ namespace Unity.Mathematics
         /// <remarks>
         /// Components of x must be greater than 0, otherwise the result for that component is undefined.
         /// </remarks>
-        /// <param name="x"><see cref="uint2"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.uint2"/> to be used as input.</param>
         /// <returns>Componentwise ceiling of the base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int2 ceillog2(uint2 x)
@@ -3718,7 +3720,7 @@ namespace Unity.Mathematics
         /// <remarks>
         /// Components of x must be greater than 0, otherwise the result for that component is undefined.
         /// </remarks>
-        /// <param name="x"><see cref="uint3"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.uint3"/> to be used as input.</param>
         /// <returns>Componentwise ceiling of the base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int3 ceillog2(uint3 x)
@@ -3732,7 +3734,7 @@ namespace Unity.Mathematics
         /// <remarks>
         /// Components of x must be greater than 0, otherwise the result for that component is undefined.
         /// </remarks>
-        /// <param name="x"><see cref="uint4"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.uint4"/> to be used as input.</param>
         /// <returns>Componentwise ceiling of the base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int4 ceillog2(uint4 x)
@@ -3756,7 +3758,7 @@ namespace Unity.Mathematics
         /// Computes the componentwise floor of the base-2 logarithm of x.
         /// </summary>
         /// <remarks>Components of x must be greater than zero, otherwise the result of the component is undefined.</remarks>
-        /// <param name="x"><see cref="int2"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.int2"/> to be used as input.</param>
         /// <returns>Componentwise floor of base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int2 floorlog2(int2 x)
@@ -3768,7 +3770,7 @@ namespace Unity.Mathematics
         /// Computes the componentwise floor of the base-2 logarithm of x.
         /// </summary>
         /// <remarks>Components of x must be greater than zero, otherwise the result of the component is undefined.</remarks>
-        /// <param name="x"><see cref="int3"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.int3"/> to be used as input.</param>
         /// <returns>Componentwise floor of base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int3 floorlog2(int3 x)
@@ -3780,7 +3782,7 @@ namespace Unity.Mathematics
         /// Computes the componentwise floor of the base-2 logarithm of x.
         /// </summary>
         /// <remarks>Components of x must be greater than zero, otherwise the result of the component is undefined.</remarks>
-        /// <param name="x"><see cref="int4"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.int4"/> to be used as input.</param>
         /// <returns>Componentwise floor of base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int4 floorlog2(int4 x)
@@ -3804,7 +3806,7 @@ namespace Unity.Mathematics
         /// Computes the componentwise floor of the base-2 logarithm of x.
         /// </summary>
         /// <remarks>Components of x must be greater than zero, otherwise the result of the component is undefined.</remarks>
-        /// <param name="x"><see cref="uint2"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.uint2"/> to be used as input.</param>
         /// <returns>Componentwise floor of base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int2 floorlog2(uint2 x)
@@ -3816,7 +3818,7 @@ namespace Unity.Mathematics
         /// Computes the componentwise floor of the base-2 logarithm of x.
         /// </summary>
         /// <remarks>Components of x must be greater than zero, otherwise the result of the component is undefined.</remarks>
-        /// <param name="x"><see cref="uint3"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.uint3"/> to be used as input.</param>
         /// <returns>Componentwise floor of base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int3 floorlog2(uint3 x)
@@ -3828,7 +3830,7 @@ namespace Unity.Mathematics
         /// Computes the componentwise floor of the base-2 logarithm of x.
         /// </summary>
         /// <remarks>Components of x must be greater than zero, otherwise the result of the component is undefined.</remarks>
-        /// <param name="x"><see cref="uint4"/> to be used as input.</param>
+        /// <param name="x"><see cref="Mathematics.uint4"/> to be used as input.</param>
         /// <returns>Componentwise floor of base-2 logarithm of x.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int4 floorlog2(uint4 x)

--- a/src/Unity.Mathematics/quaternion.cs
+++ b/src/Unity.Mathematics/quaternion.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 using static Unity.Mathematics.math;
 
 namespace Unity.Mathematics
 {
+    [Il2CppEagerStaticClassConstruction]
     [Serializable]
     public partial struct quaternion : System.IEquatable<quaternion>, IFormattable
     {

--- a/src/Unity.Mathematics/random.cs
+++ b/src/Unity.Mathematics/random.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using static Unity.Mathematics.math;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 namespace Unity.Mathematics
 {
@@ -11,6 +12,7 @@ namespace Unity.Mathematics
     /// Core functionality is integer multiplication free to improve vectorization
     /// on less capable SIMD instruction sets.
     /// </summary>
+    [Il2CppEagerStaticClassConstruction]
     [Serializable]
     public partial struct Random
     {

--- a/src/Unity.Mathematics/rigid_transform.cs
+++ b/src/Unity.Mathematics/rigid_transform.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 using static Unity.Mathematics.math;
 
 namespace Unity.Mathematics
 {
+    [Il2CppEagerStaticClassConstruction]
     [Serializable]
     public struct RigidTransform
     {

--- a/src/Unity.Mathematics/uint2.gen.cs
+++ b/src/Unity.Mathematics/uint2.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(uint2.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint2 : System.IEquatable<uint2>, IFormattable
     {
         public uint x;

--- a/src/Unity.Mathematics/uint2x2.gen.cs
+++ b/src/Unity.Mathematics/uint2x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint2x2 : System.IEquatable<uint2x2>, IFormattable
     {
         public uint2 c0;

--- a/src/Unity.Mathematics/uint2x3.gen.cs
+++ b/src/Unity.Mathematics/uint2x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint2x3 : System.IEquatable<uint2x3>, IFormattable
     {
         public uint2 c0;

--- a/src/Unity.Mathematics/uint2x4.gen.cs
+++ b/src/Unity.Mathematics/uint2x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint2x4 : System.IEquatable<uint2x4>, IFormattable
     {
         public uint2 c0;

--- a/src/Unity.Mathematics/uint3.gen.cs
+++ b/src/Unity.Mathematics/uint3.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(uint3.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint3 : System.IEquatable<uint3>, IFormattable
     {
         public uint x;

--- a/src/Unity.Mathematics/uint3x2.gen.cs
+++ b/src/Unity.Mathematics/uint3x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint3x2 : System.IEquatable<uint3x2>, IFormattable
     {
         public uint3 c0;

--- a/src/Unity.Mathematics/uint3x3.gen.cs
+++ b/src/Unity.Mathematics/uint3x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint3x3 : System.IEquatable<uint3x3>, IFormattable
     {
         public uint3 c0;

--- a/src/Unity.Mathematics/uint3x4.gen.cs
+++ b/src/Unity.Mathematics/uint3x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint3x4 : System.IEquatable<uint3x4>, IFormattable
     {
         public uint3 c0;

--- a/src/Unity.Mathematics/uint4.gen.cs
+++ b/src/Unity.Mathematics/uint4.gen.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
@@ -16,6 +17,7 @@ namespace Unity.Mathematics
 {
     [DebuggerTypeProxy(typeof(uint4.DebuggerProxy))]
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint4 : System.IEquatable<uint4>, IFormattable
     {
         public uint x;

--- a/src/Unity.Mathematics/uint4x2.gen.cs
+++ b/src/Unity.Mathematics/uint4x2.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint4x2 : System.IEquatable<uint4x2>, IFormattable
     {
         public uint4 c0;

--- a/src/Unity.Mathematics/uint4x3.gen.cs
+++ b/src/Unity.Mathematics/uint4x3.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint4x3 : System.IEquatable<uint4x3>, IFormattable
     {
         public uint4 c0;

--- a/src/Unity.Mathematics/uint4x4.gen.cs
+++ b/src/Unity.Mathematics/uint4x4.gen.cs
@@ -8,12 +8,14 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Runtime.CompilerServices;
+using Unity.IL2CPP.CompilerServices;
 
 #pragma warning disable 0660, 0661
 
 namespace Unity.Mathematics
 {
     [System.Serializable]
+    [Il2CppEagerStaticClassConstruction]
     public partial struct uint4x4 : System.IEquatable<uint4x4>, IFormattable
     {
         public uint4 c0;


### PR DESCRIPTION
[Il2CppEagerStaticClassConstruction] makes it so that Unity will run
static constructors eagerly at start time rather than lazily at
execution time.

DOTS-2113