### PR TITLE
Added xmldoc comments to noise functions.

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -27,6 +27,8 @@
 * Added `Random.CreateFromIndex()` to assist in creating Random instances from loop indices.
 
 ### Changed
+* Changed noise documentation in comments to xmldoc comments.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Unity.Mathematics/Noise/cellular2D.cs
+++ b/src/Unity.Mathematics/Noise/cellular2D.cs
@@ -10,8 +10,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        // Cellular noise, returning F1 and F2 in a float2.
-        // Standard 3x3 search window for good F1 and F2 values
+        /// <summary>
+        /// 2D Cellular noise ("Worley noise") with standard 3x3 search window for good feature point values.
+        /// </summary>
+        /// <param name="P">A point in 2D space.</param>
+        /// <returns>Feature points. F1 is in the x component, F2 in the y component.</returns>
         public static float2 cellular(float2 P)
         {
             const float K = 0.142857142857f; // 1/7

--- a/src/Unity.Mathematics/Noise/cellular2x2.cs
+++ b/src/Unity.Mathematics/Noise/cellular2x2.cs
@@ -10,12 +10,12 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        // Cellular noise, returning F1 and F2 in a float2.
-        // Speeded up by umath.sing 2x2 search window instead of 3x3,
-        // at the expense of some strong pattern artifacts.
-        // F2 is often wrong and has sharp discontinuities.
-        // If you need a smooth F2, use the slower 3x3 version.
-        // F1 is sometimes wrong, too, but OK for most purposes.
+        /// <summary>
+        /// 2D Cellular noise ("Worley noise") with a 2x2 search window. Faster than using 3x3, at the expense of some strong pattern artifacts.
+        /// F2 is often wrong and has sharp discontinuities. If you need a smooth F2, use the slower 3x3 version. F1 is sometimes wrong, too, but OK for most purposes.
+        /// </summary>
+        /// <param name="P">A point in 2D space.</param>
+        /// <returns>Feature points. F1 is in the x component, F2 in the y component.</returns>
         public static float2 cellular2x2(float2 P)
         {
             const float K = 0.142857142857f; // 1/7

--- a/src/Unity.Mathematics/Noise/cellular2x2.cs
+++ b/src/Unity.Mathematics/Noise/cellular2x2.cs
@@ -11,9 +11,11 @@ namespace Unity.Mathematics
     public static partial class noise
     {
         /// <summary>
-        /// 2D Cellular noise ("Worley noise") with a 2x2 search window. Faster than using 3x3, at the expense of some strong pattern artifacts.
-        /// F2 is often wrong and has sharp discontinuities. If you need a smooth F2, use the slower 3x3 version. F1 is sometimes wrong, too, but OK for most purposes.
+        /// 2D Cellular noise ("Worley noise") with a 2x2 search window.
         /// </summary>
+        /// <remarks>
+        /// Faster than using 3x3, at the expense of some strong pattern artifacts. F2 is often wrong and has sharp discontinuities. If you need a smooth F2, use the slower 3x3 version. F1 is sometimes wrong, too, but OK for most purposes.
+        /// </remarks>
         /// <param name="P">A point in 2D space.</param>
         /// <returns>Feature points. F1 is in the x component, F2 in the y component.</returns>
         public static float2 cellular2x2(float2 P)

--- a/src/Unity.Mathematics/Noise/cellular2x2x2.cs
+++ b/src/Unity.Mathematics/Noise/cellular2x2x2.cs
@@ -10,11 +10,12 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        // Cellular noise, returning F1 and F2 in a float2.
-        // Speeded up by umath.sing 2x2x2 search window instead of 3x3x3,
-        // at the expense of some pattern artifacts.
-        // F2 is often wrong and has sharp discontinuities.
-        // If you need a good F2, use the slower 3x3x3 version.
+        /// <summary>
+        /// 3D Cellular noise ("Worley noise") with a 2x2x2 search window. Faster than using 3x3x3, at the expense of some pattern artifacts.
+        /// F2 is often wrong and has sharp discontinuities. If you need a smooth F2, use the slower 3x3x3 version.
+        /// </summary>
+        /// <param name="P">A point in 3D space.</param>
+        /// <returns>Feature points. F1 is in the x component, F2 in the y component.</returns>
         public static float2 cellular2x2x2(float3 P)
         {
             const float K = 0.142857142857f; // 1/7

--- a/src/Unity.Mathematics/Noise/cellular2x2x2.cs
+++ b/src/Unity.Mathematics/Noise/cellular2x2x2.cs
@@ -11,9 +11,11 @@ namespace Unity.Mathematics
     public static partial class noise
     {
         /// <summary>
-        /// 3D Cellular noise ("Worley noise") with a 2x2x2 search window. Faster than using 3x3x3, at the expense of some pattern artifacts.
-        /// F2 is often wrong and has sharp discontinuities. If you need a smooth F2, use the slower 3x3x3 version.
+        /// 3D Cellular noise ("Worley noise") with a 2x2x2 search window.
         /// </summary>
+        /// <remarks>
+        /// Faster than using 3x3x3, at the expense of some pattern artifacts. F2 is often wrong and has sharp discontinuities. If you need a smooth F2, use the slower 3x3x3 version.
+        /// </remarks>
         /// <param name="P">A point in 3D space.</param>
         /// <returns>Feature points. F1 is in the x component, F2 in the y component.</returns>
         public static float2 cellular2x2x2(float3 P)

--- a/src/Unity.Mathematics/Noise/cellular3D.cs
+++ b/src/Unity.Mathematics/Noise/cellular3D.cs
@@ -10,9 +10,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        // Cellular noise, returning F1 and F2 in a float2.
-        // 3x3x3 search region for good F2 everywhere, but a lot
-        // slower than the 2x2x2 version.
+        /// <summary>
+        /// 3D Cellular noise ("Worley noise") with 3x3x3 search region for good F2 everywhere, but a lot slower than the 2x2x2 version.
+        /// </summary>
+        /// <param name="P">A point in 2D space.</param>
+        /// <returns>Feature points. F1 is in the x component, F2 in the y component.</returns>
         // The code below is a bit scary even to its author,
         // but it has at least half decent performance on a
         // math.modern GPU. In any case, it beats any software

--- a/src/Unity.Mathematics/Noise/classicnoise2D.cs
+++ b/src/Unity.Mathematics/Noise/classicnoise2D.cs
@@ -18,7 +18,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        // Classic Perlin noise
+        /// <summary>
+        /// Classic Perlin noise
+        /// </summary>
+        /// <param name="P">Point on a 2D grid of gradient vectors.</param>
+        /// <returns>Noise value.</returns>
         public static float cnoise(float2 P)
         {
             float4 Pi = floor(P.xyxy) + float4(0.0f, 0.0f, 1.0f, 1.0f);
@@ -58,7 +62,12 @@ namespace Unity.Mathematics
             return 2.3f * n_xy;
         }
 
-        // Classic Perlin noise, periodic variant
+        /// <summary>
+        /// Classic Perlin noise, periodic variant
+        /// </summary>
+        /// <param name="P">Point on a 2D grid of gradient vectors.</param>
+        /// <param name="rep">Period of repetition.</param>
+        /// <returns>Noise value.</returns>
         public static float pnoise(float2 P, float2 rep)
         {
             float4 Pi = floor(P.xyxy) + float4(0.0f, 0.0f, 1.0f, 1.0f);

--- a/src/Unity.Mathematics/Noise/classicnoise3D.cs
+++ b/src/Unity.Mathematics/Noise/classicnoise3D.cs
@@ -18,7 +18,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        // Classic Perlin noise
+        /// <summary>
+        /// Classic Perlin noise
+        /// </summary>
+        /// <param name="P">Point on a 3D grid of gradient vectors.</param>
+        /// <returns>Noise value.</returns>
         public static float cnoise(float3 P)
         {
             float3 Pi0 = floor(P); // Integer part for indexing
@@ -88,7 +92,12 @@ namespace Unity.Mathematics
             return 2.2f * n_xyz;
         }
 
-        // Classic Perlin noise, periodic variant
+        /// <summary>
+        /// Classic Perlin noise, periodic variant
+        /// </summary>
+        /// <param name="P">Point on a 3D grid of gradient vectors.</param>
+        /// <param name="rep">Period of repetition.</param>
+        /// <returns>Noise value.</returns>
         public static float pnoise(float3 P, float3 rep)
         {
             float3 Pi0 = fmod(floor(P), rep); // Integer part, math.modulo period

--- a/src/Unity.Mathematics/Noise/classicnoise4D.cs
+++ b/src/Unity.Mathematics/Noise/classicnoise4D.cs
@@ -18,7 +18,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        // Classic Perlin noise
+        /// <summary>
+        /// Classic Perlin noise
+        /// </summary>
+        /// <param name="P">Point on a 4D grid of gradient vectors.</param>
+        /// <returns>Noise value.</returns>
         public static float cnoise(float4 P)
         {
             float4 Pi0 = floor(P); // Integer part for indexing
@@ -153,7 +157,12 @@ namespace Unity.Mathematics
             return 2.2f * n_xyzw;
         }
 
-        // Classic Perlin noise, periodic version
+        /// <summary>
+        /// Classic Perlin noise, periodic variant
+        /// </summary>
+        /// <param name="P">Point on a 4D grid of gradient vectors.</param>
+        /// <param name="rep">Period of repetition.</param>
+        /// <returns>Noise value.</returns>
         public static float pnoise(float4 P, float4 rep)
         {
             float4 Pi0 = fmod(floor(P), rep); // Integer part math.modulo rep

--- a/src/Unity.Mathematics/Noise/noise2D.cs
+++ b/src/Unity.Mathematics/Noise/noise2D.cs
@@ -15,6 +15,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
+        /// <summary>
+        /// Simplex noise.
+        /// </summary>
+        /// <param name="v">Input coordinate.</param>
+        /// <returns>Noise value.</returns>
         public static float snoise(float2 v)
         {
             float4 C = float4(0.211324865405187f,  // (3.0-math.sqrt(3.0))/6.0

--- a/src/Unity.Mathematics/Noise/noise3D.cs
+++ b/src/Unity.Mathematics/Noise/noise3D.cs
@@ -16,6 +16,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
+        /// <summary>
+        /// Simplex noise.
+        /// </summary>
+        /// <param name="v">Input coordinate.</param>
+        /// <returns>Noise value.</returns>
         public static float snoise(float3 v)
         {
             float2 C = float2(1.0f / 6.0f, 1.0f / 3.0f);

--- a/src/Unity.Mathematics/Noise/noise3Dgrad.cs
+++ b/src/Unity.Mathematics/Noise/noise3Dgrad.cs
@@ -16,6 +16,12 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
+        /// <summary>
+        /// Simplex noise.
+        /// </summary>
+        /// <param name="v">Input coordinate.</param>
+        /// <param name="gradient">Output 3D noise gradient.</param>
+        /// <returns>Noise value.</returns>
         public static float snoise(float3 v, out float3 gradient)
         {
             float2 C = float2(1.0f / 6.0f, 1.0f / 3.0f);

--- a/src/Unity.Mathematics/Noise/noise4D.cs
+++ b/src/Unity.Mathematics/Noise/noise4D.cs
@@ -16,6 +16,11 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
+        /// <summary>
+        /// Simplex noise.
+        /// </summary>
+        /// <param name="v">Input coordinate.</param>
+        /// <returns>Noise value.</returns>
         public static float snoise(float4 v)
         {
             // (math.sqrt(5) - 1)/4 = F4, used once below

--- a/src/Unity.Mathematics/Noise/psrdnoise2D.cs
+++ b/src/Unity.Mathematics/Noise/psrdnoise2D.cs
@@ -73,11 +73,13 @@ namespace Unity.Mathematics
 {
     public static partial class noise
     {
-        //
-        // 2-D tiling simplex noise with rotating gradients and analytical derivative.
-        // The first component of the 3-element return vector is the noise value,
-        // and the second and third components are the x and y partial derivatives.
-        //
+        /// <summary>
+        /// 2-D tiling simplex noise with rotating gradients and analytical derivative.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <param name="per">The x and y period, where per.x is a positive integer and per.y is a positive even integer.</param>
+        /// <param name="rot">Angle to rotate the gradients.</param>
+        /// <returns>The first component of the 3-element return vector is the noise value, and the second and third components are the x and y partial derivatives.</returns>
         public static float3 psrdnoise(float2 pos, float2 per, float rot)
         {
             // Hack: offset y slightly to hide some rare artifacts
@@ -166,21 +168,24 @@ namespace Unity.Mathematics
             return 11.0f * float3(n, dn0 + dn1 + dn2);
         }
 
-        //
-        // 2-D tiling simplex noise with fixed gradients
-        // and analytical derivative.
-        // This function is implemented as a wrapper to "psrdnoise",
-        // at the math.minimal math.cost of three extra additions.
-        //
+        /// <summary>
+        /// 2-D tiling simplex noise with fixed gradients and analytical derivative.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <param name="per">The x and y period, where per.x is a positive integer and per.y is a positive even integer.</param>
+        /// <returns>The first component of the 3-element return vector is the noise value, and the second and third components are the x and y partial derivatives.</returns>
         public static float3 psrdnoise(float2 pos, float2 per)
         {
             return psrdnoise(pos, per, 0.0f);
         }
 
-        //
-        // 2-D tiling simplex noise with rotating gradients,
-        // but without the analytical derivative.
-        //
+        /// <summary>
+        /// 2-D tiling simplex noise with rotating gradients, but without the analytical derivative.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <param name="per">The x and y period, where per.x is a positive integer and per.y is a positive even integer.</param>
+        /// <param name="rot">Angle to rotate the gradients.</param>
+        /// <returns>Noise value.</returns>
         public static float psrnoise(float2 pos, float2 per, float rot)
         {
             // Offset y slightly to hide some rare artifacts
@@ -240,22 +245,23 @@ namespace Unity.Mathematics
             return 11.0f * n;
         }
 
-        //
-        // 2-D tiling simplex noise with fixed gradients,
-        // without the analytical derivative.
-        // This function is implemented as a wrapper to "psrnoise",
-        // at the math.minimal math.cost of three extra additions.
-        //
+        /// <summary>
+        /// 2-D tiling simplex noise with fixed gradients, without the analytical derivative.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <param name="per">The x and y period, where per.x is a positive integer and per.y is a positive even integer.</param>
+        /// <returns>Noise value.</returns>
         public static float psrnoise(float2 pos, float2 per)
         {
             return psrnoise(pos, per, 0.0f);
         }
 
-        //
-        // 2-D non-tiling simplex noise with rotating gradients and analytical derivative.
-        // The first component of the 3-element return vector is the noise value,
-        // and the second and third components are the x and y partial derivatives.
-        //
+        /// <summary>
+        /// 2-D non-tiling simplex noise with rotating gradients and analytical derivative.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <param name="rot">Angle to rotate the gradients.</param>
+        /// <returns>The first component of the 3-element return vector is the noise value, and the second and third components are the x and y partial derivatives.</returns>
         public static float3 srdnoise(float2 pos, float rot)
         {
             // Offset y slightly to hide some rare artifacts
@@ -346,20 +352,24 @@ namespace Unity.Mathematics
             return 11.0f * float3(n, dn0 + dn1 + dn2);
         }
 
-        //
-        // 2-D non-tiling simplex noise with fixed gradients and analytical derivative.
-        // This function is implemented as a wrapper to "srdnoise",
-        // at the math.minimal math.cost of three extra additions.
-        //
+        /// <summary>
+        /// 2-D non-tiling simplex noise with fixed gradients and analytical derivative.
+        /// This function is implemented as a wrapper to "srdnoise",
+        /// at the math.minimal math.cost of three extra additions.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <returns>The first component of the 3-element return vector is the noise value, and the second and third components are the x and y partial derivatives.</returns>
         public static float3 srdnoise(float2 pos)
         {
             return srdnoise(pos, 0.0f);
         }
 
-        //
-        // 2-D non-tiling simplex noise with rotating gradients,
-        // without the analytical derivative.
-        //
+        /// <summary>
+        /// 2-D non-tiling simplex noise with rotating gradients, without the analytical derivative.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <param name="rot">Angle to rotate the gradients.</param>
+        /// <returns>Noise value.</returns>
         public static float srnoise(float2 pos, float rot)
         {
             // Offset y slightly to hide some rare artifacts
@@ -421,16 +431,18 @@ namespace Unity.Mathematics
             return 11.0f * n;
         }
 
-        //
-        // 2-D non-tiling simplex noise with fixed gradients,
-        // without the analytical derivative.
-        // This function is implemented as a wrapper to "srnoise",
-        // at the math.minimal math.cost of three extra additions.
-        // Note: if this kind of noise is all you want, there are faster
-        // GLSL implementations of non-tiling simplex noise out there.
-        // This one is included mainly for completeness and compatibility
-        // with the other functions in the file.
-        //
+        /// <summary>
+        /// 2-D non-tiling simplex noise with fixed gradients,
+        /// without the analytical derivative.
+        /// This function is implemented as a wrapper to "srnoise",
+        /// at the math.minimal math.cost of three extra additions.
+        /// Note: if this kind of noise is all you want, there are faster
+        /// GLSL implementations of non-tiling simplex noise out there.
+        /// This one is included mainly for completeness and compatibility
+        /// with the other functions in the file.
+        /// </summary>
+        /// <param name="pos">Input (x,y) coordinate.</param>
+        /// <returns>Noise value.</returns>
         public static float srnoise(float2 pos)
         {
             return srnoise(pos, 0.0f);

--- a/src/Unity.Mathematics/Noise/psrdnoise2D.cs
+++ b/src/Unity.Mathematics/Noise/psrdnoise2D.cs
@@ -354,8 +354,6 @@ namespace Unity.Mathematics
 
         /// <summary>
         /// 2-D non-tiling simplex noise with fixed gradients and analytical derivative.
-        /// This function is implemented as a wrapper to "srdnoise",
-        /// at the math.minimal math.cost of three extra additions.
         /// </summary>
         /// <param name="pos">Input (x,y) coordinate.</param>
         /// <returns>The first component of the 3-element return vector is the noise value, and the second and third components are the x and y partial derivatives.</returns>
@@ -432,14 +430,7 @@ namespace Unity.Mathematics
         }
 
         /// <summary>
-        /// 2-D non-tiling simplex noise with fixed gradients,
-        /// without the analytical derivative.
-        /// This function is implemented as a wrapper to "srnoise",
-        /// at the math.minimal math.cost of three extra additions.
-        /// Note: if this kind of noise is all you want, there are faster
-        /// GLSL implementations of non-tiling simplex noise out there.
-        /// This one is included mainly for completeness and compatibility
-        /// with the other functions in the file.
+        /// 2-D non-tiling simplex noise with fixed gradients, without the analytical derivative.
         /// </summary>
         /// <param name="pos">Input (x,y) coordinate.</param>
         /// <returns>Noise value.</returns>


### PR DESCRIPTION
I can never find Perlin noise when I need it, so I added documentation comments for all the noise functions. Searching for Perlin noise in the documentation should return something after this goes in.