### PR TITLE
Archive vetting test results to unblock publish

### DIFF
--- a/.yamato/expectations/upm-ci.unfolded.yaml
+++ b/.yamato/expectations/upm-ci.unfolded.yaml
@@ -257,6 +257,9 @@ validate_package_minimal:
     packages: 
       paths:
         - upm-ci~/packages/**/*
+    test_results: 
+      paths:
+        - upm-ci~/**/*
   commands:
     - npm install upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm -g
     - upm-ci package pack --package-path src/

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -65,6 +65,9 @@ validate_package_minimal:
     packages:
       paths:
         - "upm-ci~/packages/**/*"
+    test_results:
+      paths:
+          - "upm-ci~/**/*"
   dependencies:
     {% for platform in build_platforms %}
     {% unless platform.name == "linux" %}


### PR DESCRIPTION
Publishing currently fails ([example](https://yamato.prd.cds.internal.unity3d.com/jobs/212-Unity.Mathematics/tree/1.2.0%2520%28tag%29/.yamato%252Fupm-ci.yml%2523publish/3023395/job/pipeline)) due to not finding test results from the `upm-ci package test` run in `Validate Package Linux Minimal` job.

Likely this broke due to some refactoring in https://github.com/Unity-Technologies/Unity.Mathematics/commit/d34adde4dc163fed544334b513cbccce2ceb839a# or similar PR.

This PR adds archiving of these results, which should unblock the Publish job.