### PR TITLE
Fix .npmignore to ignore some files/dirs *and* their meta files.

### DIFF
--- a/src/.npmignore
+++ b/src/.npmignore
@@ -8,13 +8,13 @@ Documentation/ApiDocs/**
 .gitignore
 QAReport.md
 QAReport.md.meta
-Unity.Mathematics.CodeGen
-Unity.Mathematics.PerformanceTests
-Unity.Mathematics.Shaders
-*.sln
-*.db
-**/*.csproj
-**/packages.config
+Unity.Mathematics.CodeGen*
+Unity.Mathematics.PerformanceTests*
+Unity.Mathematics.Shaders*
+*.sln*
+*.db*
+**/*.csproj*
+**/packages.config*
 **/bin
 **/obj
 


### PR DESCRIPTION
Upon publishing 1.2.0 to candidates, when testing in Entities, I
noticed a bunch of warnings for meta files existing but the files they
represent not being on disk. This appeared to be due to the .npmignore
being too specific about keeping the meta files around.