### PR TITLE
Fix float2x2.Rotate() documentation to use radians.

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 * Fixed Equals(object) override which did not check type before casting. This could cause exceptions to be thrown when the object did not match the expected type.
 * Fixed incorrect `math.tzcnt` documentation which mentioned leading zero counts instead of trailing zero counts.
+* Fixed `float2x2.Rotate` documentation to mention radians instead of degrees.
 
 ### Internal (Not ready for production)
 

--- a/src/Unity.Mathematics/matrix.cs
+++ b/src/Unity.Mathematics/matrix.cs
@@ -5,7 +5,15 @@ namespace Unity.Mathematics
 {
     public partial struct float2x2
     {
-        /// <summary>Returns a float2x2 matrix representing a counter-clockwise rotation of angle degrees.</summary>
+        /// <summary>
+        /// Computes a float2x2 matrix representing a counter-clockwise rotation by an angle in radians.
+        /// </summary>
+        /// <remarks>
+        /// A positive rotation angle will produce a counter-clockwise rotation and a negative rotation angle will
+        /// produce a clockwise rotation.
+        /// </remarks>
+        /// <param name="angle">Rotation angle in radians.</param>
+        /// <returns>Returns the 2x2 rotation matrix.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float2x2 Rotate(float angle)
         {


### PR DESCRIPTION
Closes #178, DOTS-3008.