### PR TITLE
Fixed the floatX property drawer to support fields inside polymorphic objects

### DIFF
--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -42,7 +42,15 @@ namespace Unity.Mathematics.Editor
         {
             var subLabels = Content.labels4;
             var startIter = "x";
-            switch (property.type[property.type.Length - 1])
+            var propertyType = property.type;
+            var isManagedRef = property.type.StartsWith("managedReference", StringComparison.Ordinal);
+            if (isManagedRef)
+            {
+                var startIndex = "managedReference<".Length;
+                var length = propertyType.Length - startIndex - 1;
+                propertyType = propertyType.Substring("managedReference<".Length, length);
+            }
+            switch (propertyType[propertyType.Length - 1])
             {
                 case '2':
                     subLabels = Content.labels2;

--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -12,6 +12,25 @@ namespace Unity.Mathematics.Editor
     [CustomPropertyDrawer(typeof(DoNotNormalizeAttribute))]
     class PrimitiveVectorDrawer : PropertyDrawer
     {
+        private string _PropertyType;
+
+        string GetPropertyType(SerializedProperty property)
+        {
+            if (_PropertyType == null)
+            {
+                _PropertyType = property.type;
+                var isManagedRef = property.type.StartsWith("managedReference", StringComparison.Ordinal);
+                if (isManagedRef)
+                {
+                    var startIndex = "managedReference<".Length;
+                    var length = _PropertyType.Length - startIndex - 1;
+                    _PropertyType = _PropertyType.Substring("managedReference<".Length, length);
+                }
+            }
+
+            return _PropertyType;
+        }
+
         static class Content
         {
             public static readonly string doNotNormalizeCompatibility = L10n.Tr(
@@ -42,14 +61,7 @@ namespace Unity.Mathematics.Editor
         {
             var subLabels = Content.labels4;
             var startIter = "x";
-            var propertyType = property.type;
-            var isManagedRef = property.type.StartsWith("managedReference", StringComparison.Ordinal);
-            if (isManagedRef)
-            {
-                var startIndex = "managedReference<".Length;
-                var length = propertyType.Length - startIndex - 1;
-                propertyType = propertyType.Substring("managedReference<".Length, length);
-            }
+            var propertyType = GetPropertyType(property);
             switch (propertyType[propertyType.Length - 1])
             {
                 case '2':


### PR DESCRIPTION
This PR fixes the property drawer for float2/3/4 fields inside polymorphic objects. 

Consider the following

```
[Serializable]
public class ConcreteValue
{
   [SerializeReference]
    public object _Value;
}

var ConcreteValue val = new ConcreteValue { _Value = new float2(1.0f, 1.0f) }; 
```
In this case, the `SerializedProperty.type` of the `_Value` property is `managedReference<float2>`. 

This results in the following UI bug
![image](https://user-images.githubusercontent.com/32939797/104759048-510ec780-572d-11eb-98eb-7334a07d8772.png)

This PR fixes the parsing of the SerializedProperty type string for polymorphic objects. 