### PR TITLE
DOTS-5107: Fix vector drawing in the inspector.

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Deprecated
 ### Removed
 ### Fixed
+* Fixed property drawing when manually drawing a property that was hidden with [HideInInspector].
 
 ## [1.2.4] - 2021-09-22
 ### Added

--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -90,11 +90,22 @@ namespace Unity.Mathematics.Editor
                 label.tooltip = Content.doNotNormalizeTooltip;
 
             label = EditorGUI.BeginProperty(position, label, property);
-            EditorGUICopy.MultiPropertyField(position, subLabels, property.FindPropertyRelative(startIter), label);
+            var valuesIterator = property.FindPropertyRelative(startIter);
+            MultiPropertyField(position, subLabels, valuesIterator, label);
             EditorGUI.EndProperty();
+        }
+
+        void MultiPropertyField(Rect position, GUIContent[] subLabels, SerializedProperty valuesIterator, GUIContent label)
+        {
+#if UNITY_2022_1_OR_NEWER
+            EditorGUI.MultiPropertyField(position, subLabels, valuesIterator, label, EditorGUI.PropertyVisibility.All);
+#else
+            EditorGUICopy.MultiPropertyField(position, subLabels, valuesIterator, label);
+#endif
         }
     }
 
+#if !UNITY_2022_1_OR_NEWER
     internal class EditorGUICopy
     {
         internal const float kSingleLineHeight = 18f;
@@ -226,4 +237,5 @@ namespace Unity.Mathematics.Editor
             }
         }
     }
+#endif
 }

--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -108,7 +108,6 @@ namespace Unity.Mathematics.Editor
 #if !UNITY_2022_1_OR_NEWER
     internal class EditorGUICopy
     {
-        internal const float kSingleLineHeight = 18f;
         internal const float kSpacingSubLabel = 4;
         private const float kIndentPerLevel = 15;
         internal const float kPrefixPaddingRight = 2;
@@ -135,7 +134,7 @@ namespace Unity.Mathematics.Editor
         {
             int id = GUIUtility.GetControlID(s_FoldoutHash, FocusType.Keyboard, position);
             position = MultiFieldPrefixLabel(position, id, label, subLabels.Length);
-            position.height = kSingleLineHeight;
+            position.height = EditorGUIUtility.singleLineHeight;
             MultiPropertyFieldInternal(position, subLabels, valuesIterator, PropertyVisibility.All);
         }
 
@@ -211,7 +210,7 @@ namespace Unity.Mathematics.Editor
 
             if (EditorGUIUtility.wideMode)
             {
-                Rect labelPosition = new Rect(totalPosition.x + indent, totalPosition.y, EditorGUIUtility.labelWidth - indent, kSingleLineHeight);
+                Rect labelPosition = new Rect(totalPosition.x + indent, totalPosition.y, EditorGUIUtility.labelWidth - indent, EditorGUIUtility.singleLineHeight);
                 Rect fieldPosition = totalPosition;
                 fieldPosition.xMin += EditorGUIUtility.labelWidth + kPrefixPaddingRight;
 
@@ -228,10 +227,10 @@ namespace Unity.Mathematics.Editor
             }
             else
             {
-                Rect labelPosition = new Rect(totalPosition.x + indent, totalPosition.y, totalPosition.width - indent, kSingleLineHeight);
+                Rect labelPosition = new Rect(totalPosition.x + indent, totalPosition.y, totalPosition.width - indent, EditorGUIUtility.singleLineHeight);
                 Rect fieldPosition = totalPosition;
                 fieldPosition.xMin += indent + kIndentPerLevel;
-                fieldPosition.yMin += kSingleLineHeight + kVerticalSpacingMultiField;
+                fieldPosition.yMin += EditorGUIUtility.singleLineHeight + kVerticalSpacingMultiField;
                 EditorGUI.HandlePrefixLabel(totalPosition, labelPosition, label, id);
                 return fieldPosition;
             }


### PR DESCRIPTION
It was possible for a vector to be marked as hidden in the inspector but still manually draw it in a custom drawer. When this happened, the property drawing was not correct because it would show some unrelated visible fields in place of the YZW fields of a vector.

Here is an example without the fix (see the YZ and YZW components of "Hidden int 3" and "Hidden Quaternion" respectively):

![image](https://user-images.githubusercontent.com/3121968/136279198-f4c747e9-24aa-4e4c-a1ed-493e267d4af0.png)

Here is the same example, but with the fix:

![image](https://user-images.githubusercontent.com/3121968/136279282-3b4cc6e8-43d5-4c88-874e-8175be5bb5eb.png)
