### PR TITLE
Make performance tests create a variable for iteration count.

### DIFF
--- a/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
+++ b/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
@@ -3722,6 +3722,7 @@ namespace Unity.Mathematics.Mathematics.CodeGen
             str.AppendFormat("\t\t[BurstCompile(CompileSynchronously = true)]\n");
             str.AppendFormat("\t\tpublic unsafe class {0}\n", testName);
             str.AppendFormat("\t\t{{\n");
+            str.AppendFormat("\t\t\tpublic const int iterations = {0};\n\n", loopIterations);
             str.AppendFormat("\t\t\tpublic struct Arguments : IDisposable\n");
             str.AppendFormat("\t\t\t{{\n");
 
@@ -3736,8 +3737,8 @@ namespace Unity.Mathematics.Mathematics.CodeGen
 
             foreach (var argument in testArguments)
             {
-                str.AppendFormat("\t\t\t\t\t{0} = ({1}*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<{1}>() * {2}, UnsafeUtility.AlignOf<{1}>(), Allocator.Persistent);\n", argument.m_MemberName, argument.m_ElementType, loopIterations);
-                str.AppendFormat("\t\t\t\t\tfor (int i = 0; i < {0}; ++i)\n", loopIterations);
+                str.AppendFormat("\t\t\t\t\t{0} = ({1}*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<{1}>() * iterations, UnsafeUtility.AlignOf<{1}>(), Allocator.Persistent);\n", argument.m_MemberName, argument.m_ElementType);
+                str.AppendFormat("\t\t\t\t\tfor (int i = 0; i < iterations; ++i)\n");
                 str.AppendFormat("\t\t\t\t\t{{\n");
                 str.AppendFormat("\t\t\t\t\t    {0}[i] = {1};\n", argument.m_MemberName, argument.m_ElementInitializer);
                 str.AppendFormat("\t\t\t\t\t}}\n\n");
@@ -3758,7 +3759,7 @@ namespace Unity.Mathematics.Mathematics.CodeGen
 
             str.AppendFormat("\t\t\tpublic static void CommonTestFunction(ref Arguments args)\n");
             str.AppendFormat("\t\t\t{{\n");
-            str.AppendFormat("\t\t\t\tfor (int i = 0; i < {0}; ++i)\n", loopIterations);
+            str.AppendFormat("\t\t\t\tfor (int i = 0; i < iterations; ++i)\n");
             str.AppendFormat("\t\t\t\t{{\n");
             str.AppendFormat("\t\t\t\t\t{0}\n", loopBody);
             str.AppendFormat("\t\t\t\t}}\n");

--- a/src/Unity.Mathematics.PerformanceTests/TestConversions.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestConversions.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class quaternion_to_float3x3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public quaternion* q;
@@ -28,14 +30,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q[i] = quaternion.identity;
                     }
 
-                    f3x3 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f3x3 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f3x3[i] = float3x3.identity;
                     }
@@ -51,7 +53,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f3x3[i] = new float3x3(args.q[i]);
                 }
@@ -109,6 +111,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_to_quaternion
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public quaternion* q;
@@ -116,14 +120,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q[i] = quaternion.identity;
                     }
 
-                    f3x3 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f3x3 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f3x3[i] = float3x3.identity;
                     }
@@ -139,7 +143,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.q[i] = new quaternion(args.f3x3[i]);
                 }
@@ -197,6 +201,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4_to_half4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* f4;
@@ -204,14 +210,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f4[i] = new float4(1.0f, 2.0f, 3.0f, 4.0f);
                     }
 
-                    h4 = (half4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<half4>() * 10000, UnsafeUtility.AlignOf<half4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    h4 = (half4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<half4>() * iterations, UnsafeUtility.AlignOf<half4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         h4[i] = new half4(new float4(-1.0f, -2.0f, -3.0f, -4.0f));
                     }
@@ -227,7 +233,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.h4[i] = new half4(args.f4[i]);
                 }
@@ -285,6 +291,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class half4_to_float4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* f4;
@@ -292,14 +300,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f4[i] = new float4(1.0f, 2.0f, 3.0f, 4.0f);
                     }
 
-                    h4 = (half4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<half4>() * 10000, UnsafeUtility.AlignOf<half4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    h4 = (half4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<half4>() * iterations, UnsafeUtility.AlignOf<half4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         h4[i] = new half4(new float4(-1.0f, -2.0f, -3.0f, -4.0f));
                     }
@@ -315,7 +323,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f4[i] = new float4(args.h4[i]);
                 }
@@ -373,6 +381,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class quaternion_to_RigidTransform
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public quaternion* q;
@@ -381,20 +391,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q[i] = quaternion.identity;
                     }
 
-                    rt = (RigidTransform*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<RigidTransform>() * 10000, UnsafeUtility.AlignOf<RigidTransform>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rt = (RigidTransform*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<RigidTransform>() * iterations, UnsafeUtility.AlignOf<RigidTransform>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rt[i] = RigidTransform.identity;
                     }
 
-                    pos = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    pos = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         pos[i] = new float3();
                     }
@@ -411,7 +421,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.rt[i] = new RigidTransform(args.q[i], args.pos[i]);
                 }
@@ -469,6 +479,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class quaternion_to_float4x4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public quaternion* q;
@@ -476,14 +488,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q[i] = quaternion.identity;
                     }
 
-                    f4x4 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f4x4 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f4x4[i] = float4x4.identity;
                     }
@@ -499,7 +511,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.q[i] = new quaternion(args.f4x4[i]);
                 }
@@ -557,6 +569,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_to_quaternion
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public quaternion* q;
@@ -565,20 +579,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q[i] = quaternion.identity;
                     }
 
-                    f4x4 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f4x4 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f4x4[i] = float4x4.identity;
                     }
 
-                    f3 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f3 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f3[i] = new float3();
                     }
@@ -595,7 +609,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f4x4[i] = new float4x4(args.q[i], args.f3[i]);
                 }
@@ -653,6 +667,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4_to_uint4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* f4;
@@ -660,14 +676,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f4[i] = new float4(1.0f, 2.0f, 3.0f, 4.0f);
                     }
 
-                    u4 = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * 10000, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    u4 = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         u4[i] = new uint4(100, 101, 102, 103);
                     }
@@ -683,7 +699,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.u4[i] = new uint4(args.f4[i]);
                 }
@@ -741,6 +757,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class uint4_to_float4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* f4;
@@ -748,14 +766,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f4[i] = new float4(1.0f, 2.0f, 3.0f, 4.0f);
                     }
 
-                    u4 = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * 10000, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    u4 = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         u4[i] = new uint4(100, 101, 102, 103);
                     }
@@ -771,7 +789,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f4[i] = new float4(args.u4[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestFastInverse.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestFastInverse.gen.cs
@@ -21,14 +21,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_fastinverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4x4* m1;
 
                 public void Init()
                 {
-                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float4x4.identity;
                     }
@@ -43,7 +45,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.fastinverse(args.m1[i]);
                 }
@@ -101,14 +103,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double4x4_fastinverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double4x4* m1;
 
                 public void Init()
                 {
-                    m1 = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * 10000, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * iterations, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = double4x4.identity;
                     }
@@ -123,7 +127,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.fastinverse(args.m1[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestHash.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestHash.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
@@ -28,14 +30,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 100000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -51,7 +53,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -109,6 +111,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
@@ -116,14 +120,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 100000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -139,7 +143,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -197,6 +201,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float4* v;
@@ -204,14 +210,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 100000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -227,7 +233,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -285,6 +291,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double2_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public double2* v;
@@ -292,14 +300,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * 100000, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double2(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -315,7 +323,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -373,6 +381,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double3_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public double3* v;
@@ -380,14 +390,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * 100000, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double3(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -403,7 +413,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -461,6 +471,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double4_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public double4* v;
@@ -468,14 +480,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * 100000, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double4(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -491,7 +503,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -549,6 +561,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2x2_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float2x2* v;
@@ -556,14 +570,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * 100000, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2x2(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -579,7 +593,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -637,6 +651,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float3x3* v;
@@ -644,14 +660,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 100000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3x3(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -667,7 +683,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -725,6 +741,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_hash
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float4x4* v;
@@ -732,14 +750,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 100000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4x4(1.0f);
                     }
 
-                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 100000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -755,7 +773,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hash(args.v[i]);
                 }
@@ -813,6 +831,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2x2_hashwide
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float2x2* v;
@@ -820,14 +840,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * 100000, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2x2(1.0f);
                     }
 
-                    hash = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * 100000, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -843,7 +863,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hashwide(args.v[i]);
                 }
@@ -901,6 +921,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_hashwide
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float3x3* v;
@@ -908,14 +930,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 100000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3x3(1.0f);
                     }
 
-                    hash = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * 100000, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * iterations, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -931,7 +953,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hashwide(args.v[i]);
                 }
@@ -989,6 +1011,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_hashwide
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float4x4* v;
@@ -996,14 +1020,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 100000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4x4(1.0f);
                     }
 
-                    hash = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * 100000, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = 0;
                     }
@@ -1019,7 +1043,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hashwide(args.v[i]);
                 }
@@ -1077,6 +1101,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2_hashwide
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
@@ -1084,14 +1110,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 100000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2(1.0f);
                     }
 
-                    hash = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * 100000, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    hash = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         hash[i] = new uint2();
                     }
@@ -1107,7 +1133,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.hash[i] = math.hashwide(args.v[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestInverse.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestInverse.gen.cs
@@ -21,14 +21,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_inverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4x4* m1;
 
                 public void Init()
                 {
-                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float4x4.identity;
                     }
@@ -43,7 +45,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.inverse(args.m1[i]);
                 }
@@ -101,14 +103,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_inverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3x3* m1;
 
                 public void Init()
                 {
-                    m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float3x3.identity;
                     }
@@ -123,7 +127,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.inverse(args.m1[i]);
                 }
@@ -181,14 +185,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2x2_inverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2x2* m1;
 
                 public void Init()
                 {
-                    m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * 10000, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float2x2.identity;
                     }
@@ -203,7 +209,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.inverse(args.m1[i]);
                 }
@@ -261,14 +267,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double4x4_inverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double4x4* m1;
 
                 public void Init()
                 {
-                    m1 = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * 10000, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * iterations, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = double4x4.identity;
                     }
@@ -283,7 +291,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.inverse(args.m1[i]);
                 }
@@ -341,14 +349,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double3x3_inverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double3x3* m1;
 
                 public void Init()
                 {
-                    m1 = (double3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3x3>() * 10000, UnsafeUtility.AlignOf<double3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (double3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3x3>() * iterations, UnsafeUtility.AlignOf<double3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = double3x3.identity;
                     }
@@ -363,7 +373,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.inverse(args.m1[i]);
                 }
@@ -421,14 +431,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double2x2_inverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double2x2* m1;
 
                 public void Init()
                 {
-                    m1 = (double2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2x2>() * 10000, UnsafeUtility.AlignOf<double2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (double2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2x2>() * iterations, UnsafeUtility.AlignOf<double2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = double2x2.identity;
                     }
@@ -443,7 +455,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.inverse(args.m1[i]);
                 }
@@ -501,14 +513,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class quaternion_inverse
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public quaternion* q;
 
                 public void Init()
                 {
-                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q[i] = quaternion.identity;
                     }
@@ -523,7 +537,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.q[i] = math.inverse(args.q[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class orthonormal_basis_float
         {
+            public const int iterations = 1000000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -30,26 +32,26 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 1000000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Random(1234u);
                     }
 
-                    v1 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 1000000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    v1 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v1[i] = rng[0].NextFloat3Direction();
                     }
 
-                    v2 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 1000000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    v2 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v2[i] = new float3();
                     }
 
-                    v3 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 1000000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    v3 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v3[i] = new float3();
                     }
@@ -67,7 +69,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 1000000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     math.orthonormal_basis(args.v1[i], out args.v2[i], out args.v3[i]);
                 }
@@ -125,6 +127,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class orthonormal_basis_double
         {
+            public const int iterations = 1000000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -134,26 +138,26 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 1000000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Random(1234u);
                     }
 
-                    v1 = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * 1000000, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    v1 = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v1[i] = rng[0].NextDouble3Direction();
                     }
 
-                    v2 = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * 1000000, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    v2 = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v2[i] = new double();
                     }
 
-                    v3 = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * 1000000, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
-                    for (int i = 0; i < 1000000; ++i)
+                    v3 = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v3[i] = new double();
                     }
@@ -171,7 +175,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 1000000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     math.orthonormal_basis(args.v1[i], out args.v2[i], out args.v3[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestMinMaxAABB.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMinMaxAABB.gen.cs
@@ -21,14 +21,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Transform_float4x4
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public Geometry.MinMaxAABB* a;
 
                 public void Init()
                 {
-                    a = (Geometry.MinMaxAABB*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Geometry.MinMaxAABB>() * 100000, UnsafeUtility.AlignOf<Geometry.MinMaxAABB>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    a = (Geometry.MinMaxAABB*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Geometry.MinMaxAABB>() * iterations, UnsafeUtility.AlignOf<Geometry.MinMaxAABB>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         a[i] = new Geometry.MinMaxAABB();
                     }
@@ -43,7 +45,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.a[i] = Geometry.Math.Transform(float4x4.identity, args.a[i]);
                 }
@@ -101,14 +103,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Transform_float3x3
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public Geometry.MinMaxAABB* a;
 
                 public void Init()
                 {
-                    a = (Geometry.MinMaxAABB*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Geometry.MinMaxAABB>() * 100000, UnsafeUtility.AlignOf<Geometry.MinMaxAABB>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    a = (Geometry.MinMaxAABB*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Geometry.MinMaxAABB>() * iterations, UnsafeUtility.AlignOf<Geometry.MinMaxAABB>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         a[i] = new Geometry.MinMaxAABB();
                     }
@@ -123,7 +127,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.a[i] = Geometry.Math.Transform(float3x3.identity, args.a[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestMul.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMul.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_float4x4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4x4* m1;
@@ -28,14 +30,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float4x4.identity;
                     }
 
-                    m2 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m2 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m2[i] = float4x4.identity;
                     }
@@ -51,7 +53,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m1[i] = math.mul(args.m1[i], args.m2[i]);
                 }
@@ -109,6 +111,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_float4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4x4* m1;
@@ -116,14 +120,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float4x4.identity;
                     }
 
-                    m2 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m2 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m2[i] = new float4(1.0f, 0.0f, 0.0f, 1.0f);
                     }
@@ -139,7 +143,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m2[i] = math.mul(args.m1[i], args.m2[i]);
                 }
@@ -197,6 +201,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class quaternion_quaternion
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public quaternion* q1;
@@ -204,14 +210,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    q1 = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q1 = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q1[i] = quaternion.identity;
                     }
 
-                    q2 = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * 10000, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    q2 = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         q2[i] = quaternion.identity;
                     }
@@ -227,7 +233,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.q2[i] = math.mul(args.q1[i], args.q2[i]);
                 }
@@ -285,6 +291,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_float3x3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3x3* m1;
@@ -292,14 +300,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float3x3.identity;
                     }
 
-                    m2 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m2 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m2[i] = float3x3.identity;
                     }
@@ -315,7 +323,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m2[i] = math.mul(args.m1[i], args.m2[i]);
                 }
@@ -373,6 +381,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2x2_float2x2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2x2* m1;
@@ -380,14 +390,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * 10000, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float2x2.identity;
                     }
 
-                    m2 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * 10000, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m2 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m2[i] = float2x2.identity;
                     }
@@ -403,7 +413,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m2[i] = math.mul(args.m1[i], args.m2[i]);
                 }
@@ -461,6 +471,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_float3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3x3* m1;
@@ -468,14 +480,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float3x3.identity;
                     }
 
-                    m2 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m2 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m2[i] = new float3(1.0f, 0.0f, 0.0f);
                     }
@@ -491,7 +503,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m2[i] = math.mul(args.m1[i], args.m2[i]);
                 }
@@ -549,6 +561,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2x2_float2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2x2* m1;
@@ -556,14 +570,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * 10000, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m1[i] = float2x2.identity;
                     }
 
-                    m2 = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m2 = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m2[i] = new float2(1.0f, 0.0f);
                     }
@@ -579,7 +593,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m2[i] = math.mul(args.m1[i], args.m2[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestNoise.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestNoise.gen.cs
@@ -21,14 +21,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class snoise2D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -43,7 +45,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.snoise(args.v[i]);
                 }
@@ -101,14 +103,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class snoise3D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3();
                     }
@@ -123,7 +127,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.snoise(args.v[i]);
                 }
@@ -181,14 +185,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class snoise4D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* v;
 
                 public void Init()
                 {
-                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4();
                     }
@@ -203,7 +209,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.snoise(args.v[i]);
                 }
@@ -261,6 +267,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class snoise3Dgrad
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
@@ -268,14 +276,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3();
                     }
 
-                    gradient = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    gradient = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         gradient[i] = new float3();
                     }
@@ -291,7 +299,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.snoise(args.v[i], out args.gradient[i]);
                 }
@@ -349,14 +357,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class cnoise2D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -371,7 +381,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.cnoise(args.v[i]);
                 }
@@ -429,14 +439,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class cnoise3D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3();
                     }
@@ -451,7 +463,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.cnoise(args.v[i]);
                 }
@@ -509,14 +521,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class cnoise4D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* v;
 
                 public void Init()
                 {
-                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4();
                     }
@@ -531,7 +545,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.cnoise(args.v[i]);
                 }
@@ -589,14 +603,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class pnoise2D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -611,7 +627,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.pnoise(args.v[i], args.v[i]);
                 }
@@ -669,14 +685,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class pnoise3D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3();
                     }
@@ -691,7 +709,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.pnoise(args.v[i], args.v[i]);
                 }
@@ -749,14 +767,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class pnoise4D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* v;
 
                 public void Init()
                 {
-                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4();
                     }
@@ -771,7 +791,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.pnoise(args.v[i], args.v[i]);
                 }
@@ -829,14 +849,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class cellular2D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -851,7 +873,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = noise.cellular(args.v[i]);
                 }
@@ -909,14 +931,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class cellular3D
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3();
                     }
@@ -931,7 +955,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].xy = noise.cellular(args.v[i]);
                 }
@@ -989,14 +1013,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class cellular2x2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -1011,7 +1037,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = noise.cellular2x2(args.v[i]);
                 }
@@ -1069,14 +1095,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class cellular2x2x2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3();
                     }
@@ -1091,7 +1119,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].xy = noise.cellular2x2x2(args.v[i]);
                 }
@@ -1149,14 +1177,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class psrdnoise
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -1171,7 +1201,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = noise.psrdnoise(args.v[i], args.v[i], args.v[i].y).xy;
                 }
@@ -1229,14 +1259,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class psrnoise
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -1251,7 +1283,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.psrnoise(args.v[i], args.v[i], args.v[i].y);
                 }
@@ -1309,14 +1341,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class srdnoise
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -1331,7 +1365,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = noise.srdnoise(args.v[i], args.v[i].y).xy;
                 }
@@ -1389,14 +1423,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class srnoise
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2();
                     }
@@ -1411,7 +1447,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i].x = noise.srnoise(args.v[i], args.v[i].y);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestNormalize.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestNormalize.gen.cs
@@ -21,14 +21,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4_normalize
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* v;
 
                 public void Init()
                 {
-                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4(1.0f);
                     }
@@ -43,7 +45,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalize(args.v[i]);
                 }
@@ -101,14 +103,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3_normalize
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3(1.0f);
                     }
@@ -123,7 +127,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalize(args.v[i]);
                 }
@@ -181,14 +185,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2_normalize
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2(1.0f);
                     }
@@ -203,7 +209,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalize(args.v[i]);
                 }
@@ -261,14 +267,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double4_normalize
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double4* v;
 
                 public void Init()
                 {
-                    v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * 10000, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double4(1.0f);
                     }
@@ -283,7 +291,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalize(args.v[i]);
                 }
@@ -341,14 +349,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double3_normalize
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double3* v;
 
                 public void Init()
                 {
-                    v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * 10000, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double3(1.0f);
                     }
@@ -363,7 +373,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalize(args.v[i]);
                 }
@@ -421,14 +431,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double2_normalize
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double2* v;
 
                 public void Init()
                 {
-                    v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * 10000, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double2(1.0f);
                     }
@@ -443,7 +455,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalize(args.v[i]);
                 }
@@ -501,14 +513,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4_normalizesafe
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* v;
 
                 public void Init()
                 {
-                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float4(1.0f);
                     }
@@ -523,7 +537,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalizesafe(args.v[i]);
                 }
@@ -581,14 +595,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3_normalizesafe
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3(1.0f);
                     }
@@ -603,7 +619,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalizesafe(args.v[i]);
                 }
@@ -661,14 +677,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2_normalizesafe
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v;
 
                 public void Init()
                 {
-                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float2(1.0f);
                     }
@@ -683,7 +701,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalizesafe(args.v[i]);
                 }
@@ -741,14 +759,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double4_normalizesafe
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double4* v;
 
                 public void Init()
                 {
-                    v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * 10000, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double4(1.0f);
                     }
@@ -763,7 +783,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalizesafe(args.v[i]);
                 }
@@ -821,14 +841,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double3_normalizesafe
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double3* v;
 
                 public void Init()
                 {
-                    v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * 10000, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double3(1.0f);
                     }
@@ -843,7 +865,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalizesafe(args.v[i]);
                 }
@@ -901,14 +923,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class double2_normalizesafe
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double2* v;
 
                 public void Init()
                 {
-                    v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * 10000, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new double2(1.0f);
                     }
@@ -923,7 +947,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.v[i] = math.normalizesafe(args.v[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestPlane.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestPlane.gen.cs
@@ -21,14 +21,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Normalize_Plane
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Plane* p;
 
                 public void Init()
                 {
-                    p = (Plane*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Plane>() * 10000, UnsafeUtility.AlignOf<Plane>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    p = (Plane*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Plane>() * iterations, UnsafeUtility.AlignOf<Plane>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         p[i] = new Plane { NormalAndDistance = new float4(1.0f) };
                     }
@@ -43,7 +45,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.p[i] = Plane.Normalize(args.p[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestRandom.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestRandom.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextUint
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -28,14 +30,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    u = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * 10000, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    u = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         u[i] = 0;
                     }
@@ -51,7 +53,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.u[i] = args.rng[i].NextUInt();
                 }
@@ -109,6 +111,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextUint2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -116,14 +120,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    u = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * 10000, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    u = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         u[i] = 0;
                     }
@@ -139,7 +143,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.u[i] = args.rng[i].NextUInt2();
                 }
@@ -197,6 +201,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextUint3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -204,14 +210,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    u = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * 10000, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    u = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * iterations, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         u[i] = 0;
                     }
@@ -227,7 +233,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.u[i] = args.rng[i].NextUInt3();
                 }
@@ -285,6 +291,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextUint4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -292,14 +300,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    u = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * 10000, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    u = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         u[i] = 0;
                     }
@@ -315,7 +323,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.u[i] = args.rng[i].NextUInt4();
                 }
@@ -373,6 +381,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextFloat
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -380,14 +390,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * 10000, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = 0.0f;
                     }
@@ -403,7 +413,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextFloat();
                 }
@@ -461,6 +471,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextFloat2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -468,14 +480,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = new float2(0.0f);
                     }
@@ -491,7 +503,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextFloat2();
                 }
@@ -549,6 +561,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextFloat3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -556,14 +570,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = new float3(0.0f);
                     }
@@ -579,7 +593,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextFloat3();
                 }
@@ -637,6 +651,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextFloat4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -644,14 +660,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = new float4(0.0f);
                     }
@@ -667,7 +683,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextFloat4();
                 }
@@ -725,6 +741,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextDouble
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -732,14 +750,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (double*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double>() * 10000, UnsafeUtility.AlignOf<double>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (double*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double>() * iterations, UnsafeUtility.AlignOf<double>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = 0.0;
                     }
@@ -755,7 +773,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextDouble();
                 }
@@ -813,6 +831,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextDouble2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -820,14 +840,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * 10000, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = new double2(0.0);
                     }
@@ -843,7 +863,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextDouble2();
                 }
@@ -901,6 +921,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextDouble3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -908,14 +930,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * 10000, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = new double3(0.0);
                     }
@@ -931,7 +953,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextDouble3();
                 }
@@ -989,6 +1011,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class Random_NextDouble4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public Random* rng;
@@ -996,14 +1020,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * 10000, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         rng[i] = new Unity.Mathematics.Random(1);
                     }
 
-                    f = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * 10000, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    f = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         f[i] = new double4(0.0);
                     }
@@ -1019,7 +1043,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.f[i] = args.rng[i].NextDouble4();
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestRotation.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestRotation.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_EulerXYZ
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
@@ -28,14 +30,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3(1.0f);
                     }
 
-                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float4x4.identity;
                     }
@@ -51,7 +53,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = float4x4.EulerXYZ(args.v[i]);
                 }
@@ -109,6 +111,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_EulerXYZ
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
@@ -116,14 +120,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = new float3(1.0f);
                     }
 
-                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float3x3.identity;
                     }
@@ -139,7 +143,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = float3x3.EulerXYZ(args.v[i]);
                 }
@@ -197,6 +201,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_AxisAngle
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
@@ -205,20 +211,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = math.normalize(new float3(1.0f));
                     }
 
-                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float4x4.identity;
                     }
 
-                    angle = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * 10000, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    angle = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         angle[i] = 1.0f;
                     }
@@ -235,7 +241,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = float4x4.AxisAngle(args.v[i], args.angle[i]);
                 }
@@ -293,6 +299,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_AxisAngle
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v;
@@ -301,20 +309,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v[i] = math.normalize(new float3(1.0f));
                     }
 
-                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float3x3.identity;
                     }
 
-                    angle = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * 10000, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    angle = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         angle[i] = 1.0f;
                     }
@@ -331,7 +339,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = float3x3.AxisAngle(args.v[i], args.angle[i]);
                 }
@@ -389,6 +397,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_LookRotation
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* forward;
@@ -397,20 +407,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    forward = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    forward = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         forward[i] = math.normalize(new float3(1.0f));
                     }
 
-                    up = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    up = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         up[i] = math.normalize(new float3(0.0f, 1.0f, 0.0f));
                     }
 
-                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float3x3.identity;
                     }
@@ -427,7 +437,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = float3x3.LookRotation(args.forward[i], args.up[i]);
                 }
@@ -485,6 +495,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3x3_LookRotationSafe
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* forward;
@@ -493,20 +505,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    forward = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    forward = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         forward[i] = math.normalize(new float3(1.0f));
                     }
 
-                    up = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    up = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         up[i] = math.normalize(new float3(0.0f, 1.0f, 0.0f));
                     }
 
-                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float3x3.identity;
                     }
@@ -523,7 +535,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = float3x3.LookRotationSafe(args.forward[i], args.up[i]);
                 }
@@ -581,6 +593,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4x4_LookAt
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* eye;
@@ -590,26 +604,26 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    eye = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    eye = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         eye[i] = math.normalize(new float3(1.0f));
                     }
 
-                    target = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    target = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         target[i] = math.normalize(new float3(0.0f, 1.0f, 0.0f));
                     }
 
-                    up = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    up = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         up[i] = math.normalize(new float3(-5.0f, 2.0f, 3.0f));
                     }
 
-                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float4x4.identity;
                     }
@@ -627,7 +641,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = float4x4.LookAt(args.eye[i], args.target[i], args.up[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestShuffle.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestShuffle.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2_shuffle
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float2* v1;
@@ -29,20 +31,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v1 = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 100000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v1 = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v1[i] = new float2(1.0f);
                     }
 
-                    v2 = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 100000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v2 = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v2[i] = new float2(2.0f);
                     }
 
-                    result = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 100000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    result = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         result[i] = new float2(1.0f);
                     }
@@ -59,7 +61,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.result[i] = math.shuffle(args.v1[i], args.v2[i], math.ShuffleComponent.RightX, math.ShuffleComponent.LeftY);
                 }
@@ -117,6 +119,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3_shuffle
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float3* v1;
@@ -125,20 +129,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v1 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 100000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v1 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v1[i] = new float3(1.0f);
                     }
 
-                    v2 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 100000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v2 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v2[i] = new float3(2.0f);
                     }
 
-                    result = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 100000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    result = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         result[i] = new float3(1.0f);
                     }
@@ -155,7 +159,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.result[i] = math.shuffle(args.v1[i], args.v2[i], math.ShuffleComponent.RightX, math.ShuffleComponent.LeftZ, math.ShuffleComponent.LeftX);
                 }
@@ -213,6 +217,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4_shuffle
         {
+            public const int iterations = 100000;
+
             public struct Arguments : IDisposable
             {
                 public float4* v1;
@@ -221,20 +227,20 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    v1 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 100000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v1 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v1[i] = new float4(1.0f);
                     }
 
-                    v2 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 100000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    v2 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         v2[i] = new float4(2.0f);
                     }
 
-                    result = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 100000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 100000; ++i)
+                    result = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         result[i] = new float4(1.0f);
                     }
@@ -251,7 +257,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 100000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.result[i] = math.shuffle(args.v1[i], args.v2[i], math.ShuffleComponent.RightX, math.ShuffleComponent.LeftZ, math.ShuffleComponent.LeftX, math.ShuffleComponent.RightY);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestTranspose.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestTranspose.gen.cs
@@ -21,14 +21,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class transpose_float4x4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4x4* m;
 
                 public void Init()
                 {
-                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * 10000, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float4x4.identity;
                     }
@@ -43,7 +45,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = math.transpose(args.m[i]);
                 }
@@ -101,14 +103,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class transpose_float3x3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3x3* m;
 
                 public void Init()
                 {
-                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * 10000, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float3x3.identity;
                     }
@@ -123,7 +127,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = math.transpose(args.m[i]);
                 }
@@ -181,14 +185,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class transpose_float2x2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2x2* m;
 
                 public void Init()
                 {
-                    m = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * 10000, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = float2x2.identity;
                     }
@@ -203,7 +209,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = math.transpose(args.m[i]);
                 }
@@ -261,14 +267,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class transpose_double4x4
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double4x4* m;
 
                 public void Init()
                 {
-                    m = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * 10000, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * iterations, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = double4x4.identity;
                     }
@@ -283,7 +291,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = math.transpose(args.m[i]);
                 }
@@ -341,14 +349,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class transpose_double3x3
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double3x3* m;
 
                 public void Init()
                 {
-                    m = (double3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3x3>() * 10000, UnsafeUtility.AlignOf<double3x3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (double3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3x3>() * iterations, UnsafeUtility.AlignOf<double3x3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = double3x3.identity;
                     }
@@ -363,7 +373,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = math.transpose(args.m[i]);
                 }
@@ -421,14 +431,16 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class transpose_double2x2
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public double2x2* m;
 
                 public void Init()
                 {
-                    m = (double2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2x2>() * 10000, UnsafeUtility.AlignOf<double2x2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    m = (double2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2x2>() * iterations, UnsafeUtility.AlignOf<double2x2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         m[i] = double2x2.identity;
                     }
@@ -443,7 +455,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     args.m[i] = math.transpose(args.m[i]);
                 }

--- a/src/Unity.Mathematics.PerformanceTests/TestTrig.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestTrig.gen.cs
@@ -21,6 +21,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float_sincos
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float* sin;
@@ -28,14 +30,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    sin = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * 10000, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    sin = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         sin[i] = 0.0f;
                     }
 
-                    cos = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * 10000, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    cos = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         cos[i] = 1.0f;
                     }
@@ -51,7 +53,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     math.sincos(args.sin[i], out args.sin[i], out args.cos[i]);
                 }
@@ -109,6 +111,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float2_sincos
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float2* sin;
@@ -116,14 +120,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    sin = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    sin = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         sin[i] = new float2(0.0f);
                     }
 
-                    cos = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * 10000, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    cos = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         cos[i] = new float2(1.0f);
                     }
@@ -139,7 +143,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     math.sincos(args.sin[i], out args.sin[i], out args.cos[i]);
                 }
@@ -197,6 +201,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float3_sincos
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float3* sin;
@@ -204,14 +210,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    sin = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    sin = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         sin[i] = new float3(0.0f);
                     }
 
-                    cos = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * 10000, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    cos = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         cos[i] = new float3(1.0f);
                     }
@@ -227,7 +233,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     math.sincos(args.sin[i], out args.sin[i], out args.cos[i]);
                 }
@@ -285,6 +291,8 @@ namespace Unity.Mathematics.PerformanceTests
         [BurstCompile(CompileSynchronously = true)]
         public unsafe class float4_sincos
         {
+            public const int iterations = 10000;
+
             public struct Arguments : IDisposable
             {
                 public float4* sin;
@@ -292,14 +300,14 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
-                    sin = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    sin = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         sin[i] = new float4(0.0f);
                     }
 
-                    cos = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * 10000, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
-                    for (int i = 0; i < 10000; ++i)
+                    cos = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
                     {
                         cos[i] = new float4(1.0f);
                     }
@@ -315,7 +323,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public static void CommonTestFunction(ref Arguments args)
             {
-                for (int i = 0; i < 10000; ++i)
+                for (int i = 0; i < iterations; ++i)
                 {
                     math.sincos(args.sin[i], out args.sin[i], out args.cos[i]);
                 }


### PR DESCRIPTION
While the performance tests worked just fine, it was annoying to hand
modify a performance test when investigating performance issues. You
had to search the code for all instances of a const literal and be
sure you changed the number in all those places. Instead, use a
variable so you can change it in one place.