### PR TITLE
Avoid using union structs for asfloat(int) and friends

### DIFF
--- a/Unity.Mathematics.TestProject/Packages/manifest.json
+++ b/Unity.Mathematics.TestProject/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.s-schoener.asmexplorer": "file:/Users/dale/code/unity-asm-explorer-package/Packages/com.s-schoener.asmexplorer",
     "com.unity.burst": "1.2.3",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.1.4",

--- a/Unity.Mathematics.TestProject/Packages/manifest.json
+++ b/Unity.Mathematics.TestProject/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.s-schoener.asmexplorer": "file:/Users/dale/code/unity-asm-explorer-package/Packages/com.s-schoener.asmexplorer",
     "com.unity.burst": "1.2.3",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.1.4",

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `math.orthonormal_basis()` to compute an orthonormal basis from a single unit length vector.
 * Added `math.sign(x)` for int, int2, int3 and int4.
 ### Changed
+* `asfloat(uint)`, `asuint(float)`, `asint(float)` and other related methods are now faster in mono without Burst. Other methods which use these will see a performance improvement.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
+++ b/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
@@ -3295,55 +3295,43 @@ namespace Unity.Mathematics.Mathematics.CodeGen
             BeginPerformanceTestCodeGen(str, "TestRandom");
 
             GeneratePerformanceTest(str, "Random_NextUint", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "uint", m_MemberName = "u", m_ElementInitializer = "0" },
-            }, "args.u[i] = args.rng[i].NextUInt();", 10000);
+            }, "args.u[i] = args.rng.NextUInt();", 10000);
             GeneratePerformanceTest(str, "Random_NextUint2", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "uint2", m_MemberName = "u", m_ElementInitializer = "0" },
-            }, "args.u[i] = args.rng[i].NextUInt2();", 10000);
+            }, "args.u[i] = args.rng.NextUInt2();", 10000);
             GeneratePerformanceTest(str, "Random_NextUint3", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "uint3", m_MemberName = "u", m_ElementInitializer = "0" },
-            }, "args.u[i] = args.rng[i].NextUInt3();", 10000);
+            }, "args.u[i] = args.rng.NextUInt3();", 10000);
             GeneratePerformanceTest(str, "Random_NextUint4", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "uint4", m_MemberName = "u", m_ElementInitializer = "0" },
-            }, "args.u[i] = args.rng[i].NextUInt4();", 10000);
+            }, "args.u[i] = args.rng.NextUInt4();", 10000);
 
             GeneratePerformanceTest(str, "Random_NextFloat", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "f", m_ElementInitializer = "0.0f" },
-            }, "args.f[i] = args.rng[i].NextFloat();", 10000);
+            }, "args.f[i] = args.rng.NextFloat();", 10000);
             GeneratePerformanceTest(str, "Random_NextFloat2", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "float2", m_MemberName = "f", m_ElementInitializer = "new float2(0.0f)" },
-            }, "args.f[i] = args.rng[i].NextFloat2();", 10000);
+            }, "args.f[i] = args.rng.NextFloat2();", 10000);
             GeneratePerformanceTest(str, "Random_NextFloat3", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "f", m_ElementInitializer = "new float3(0.0f)" },
-            }, "args.f[i] = args.rng[i].NextFloat3();", 10000);
+            }, "args.f[i] = args.rng.NextFloat3();", 10000);
             GeneratePerformanceTest(str, "Random_NextFloat4", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "float4", m_MemberName = "f", m_ElementInitializer = "new float4(0.0f)" },
-            }, "args.f[i] = args.rng[i].NextFloat4();", 10000);
+            }, "args.f[i] = args.rng.NextFloat4();", 10000);
 
             GeneratePerformanceTest(str, "Random_NextDouble", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "double", m_MemberName = "f", m_ElementInitializer = "0.0" },
-            }, "args.f[i] = args.rng[i].NextDouble();", 10000);
+            }, "args.f[i] = args.rng.NextDouble();", 10000);
             GeneratePerformanceTest(str, "Random_NextDouble2", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "double2", m_MemberName = "f", m_ElementInitializer = "new double2(0.0)" },
-            }, "args.f[i] = args.rng[i].NextDouble2();", 10000);
+            }, "args.f[i] = args.rng.NextDouble2();", 10000);
             GeneratePerformanceTest(str, "Random_NextDouble3", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "double3", m_MemberName = "f", m_ElementInitializer = "new double3(0.0)" },
-            }, "args.f[i] = args.rng[i].NextDouble3();", 10000);
+            }, "args.f[i] = args.rng.NextDouble3();", 10000);
             GeneratePerformanceTest(str, "Random_NextDouble4", new PerformanceTestArrayArgument[] {
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Unity.Mathematics.Random(1)" },
                 new PerformanceTestArrayArgument { m_ElementType = "double4", m_MemberName = "f", m_ElementInitializer = "new double4(0.0)" },
-            }, "args.f[i] = args.rng[i].NextDouble4();", 10000);
+            }, "args.f[i] = args.rng.NextDouble4();", 10000);
 
             EndPerformanceTestCodeGen(str);
         }
@@ -3691,23 +3679,25 @@ namespace Unity.Mathematics.Mathematics.CodeGen
 
             GeneratePerformanceTest(str, "orthonormal_basis_float", new PerformanceTestArrayArgument[]
             {
-                // This rng array is totally wasteful since we create loopIterations of them when we just need one.
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Random(1234u)" },
-                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "v1", m_ElementInitializer = "rng[0].NextFloat3Direction()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "v1", m_ElementInitializer = "rng.NextFloat3Direction()" },
                 new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "v2", m_ElementInitializer = "new float3()" },
                 new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "v3", m_ElementInitializer = "new float3()" },
             }, "math.orthonormal_basis(args.v1[i], out args.v2[i], out args.v3[i]);", 1000000);
 
             GeneratePerformanceTest(str, "orthonormal_basis_double", new PerformanceTestArrayArgument[]
             {
-                // This rng array is totally wasteful since we create loopIterations of them when we just need one.
-                new PerformanceTestArrayArgument { m_ElementType = "Random", m_MemberName = "rng", m_ElementInitializer = "new Random(1234u)" },
-                new PerformanceTestArrayArgument { m_ElementType = "double3", m_MemberName = "v1", m_ElementInitializer = "rng[0].NextDouble3Direction()" },
+                new PerformanceTestArrayArgument { m_ElementType = "double3", m_MemberName = "v1", m_ElementInitializer = "rng.NextDouble3Direction()" },
                 new PerformanceTestArrayArgument { m_ElementType = "double3", m_MemberName = "v2", m_ElementInitializer = "new double()" },
                 new PerformanceTestArrayArgument { m_ElementType = "double3", m_MemberName = "v3", m_ElementInitializer = "new double()" },
             }, "math.orthonormal_basis(args.v1[i], out args.v2[i], out args.v3[i]);", 1000000);
 
-            EndPerformanceTestCodeGen(str);
+            GeneratePerformanceTest(str, "asuint_float", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint", m_MemberName = "result", m_ElementInitializer = "new uint()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+
+                EndPerformanceTestCodeGen(str);
         }
 
         public struct PerformanceTestArrayArgument
@@ -3717,7 +3707,7 @@ namespace Unity.Mathematics.Mathematics.CodeGen
             public string m_ElementInitializer;
         }
 
-        void GeneratePerformanceTest(StringBuilder str, string testName, PerformanceTestArrayArgument[] testArguments, string loopBody, int loopIterations)
+        void GeneratePerformanceTest(StringBuilder str, string testName, PerformanceTestArrayArgument[] testArguments, string loopBody, int loopIterations, uint rngSeed = 1u)
         {
             str.AppendFormat("\t\t[BurstCompile(CompileSynchronously = true)]\n");
             str.AppendFormat("\t\tpublic unsafe class {0}\n", testName);
@@ -3725,6 +3715,7 @@ namespace Unity.Mathematics.Mathematics.CodeGen
             str.AppendFormat("\t\t\tpublic const int iterations = {0};\n\n", loopIterations);
             str.AppendFormat("\t\t\tpublic struct Arguments : IDisposable\n");
             str.AppendFormat("\t\t\t{{\n");
+            str.AppendFormat("\t\t\t\tpublic Random rng;\n");
 
             foreach (var argument in testArguments)
             {
@@ -3734,6 +3725,7 @@ namespace Unity.Mathematics.Mathematics.CodeGen
             str.AppendFormat("\n");
             str.AppendFormat("\t\t\t\tpublic void Init()\n");
             str.AppendFormat("\t\t\t\t{{\n");
+            str.AppendFormat("\t\t\t\t\trng = new Random({0});\n", rngSeed);
 
             foreach (var argument in testArguments)
             {

--- a/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
+++ b/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
@@ -3787,6 +3787,30 @@ namespace Unity.Mathematics.Mathematics.CodeGen
                 new PerformanceTestArrayArgument { m_ElementType = "int4", m_MemberName = "v", m_ElementInitializer = "rng.NextInt4()" },
             }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
 
+            GeneratePerformanceTest(str, "asdouble_ulong", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "double", m_MemberName = "result", m_ElementInitializer = "new double()" },
+                new PerformanceTestArrayArgument { m_ElementType = "ulong", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt()" },
+            }, "args.result[i] = math.asdouble(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asdouble_long", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "double", m_MemberName = "result", m_ElementInitializer = "new double()" },
+                new PerformanceTestArrayArgument { m_ElementType = "long", m_MemberName = "v", m_ElementInitializer = "rng.NextInt()" },
+            }, "args.result[i] = math.asdouble(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "aslong_double", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "long", m_MemberName = "result", m_ElementInitializer = "new long()" },
+                new PerformanceTestArrayArgument { m_ElementType = "double", m_MemberName = "v", m_ElementInitializer = "rng.NextDouble(-1.0, 1.0)" },
+            }, "args.result[i] = math.aslong(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asulong_double", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "ulong", m_MemberName = "result", m_ElementInitializer = "new ulong()" },
+                new PerformanceTestArrayArgument { m_ElementType = "double", m_MemberName = "v", m_ElementInitializer = "rng.NextDouble(-1.0, 1.0)" },
+            }, "args.result[i] = math.asulong(args.v[i]);", 400000);
+
             EndPerformanceTestCodeGen(str);
         }
 

--- a/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
+++ b/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
@@ -3811,6 +3811,54 @@ namespace Unity.Mathematics.Mathematics.CodeGen
                 new PerformanceTestArrayArgument { m_ElementType = "double", m_MemberName = "v", m_ElementInitializer = "rng.NextDouble(-1.0, 1.0)" },
             }, "args.result[i] = math.asulong(args.v[i]);", 400000);
 
+            GeneratePerformanceTest(str, "asuint_int", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint", m_MemberName = "result", m_ElementInitializer = "new uint()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int", m_MemberName = "v", m_ElementInitializer = "rng.NextInt()" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asuint_int2", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint2", m_MemberName = "result", m_ElementInitializer = "new uint2()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int2", m_MemberName = "v", m_ElementInitializer = "rng.NextInt2()" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asuint_int3", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint3", m_MemberName = "result", m_ElementInitializer = "new uint3()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int3", m_MemberName = "v", m_ElementInitializer = "rng.NextInt3()" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asuint_int4", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint4", m_MemberName = "result", m_ElementInitializer = "new uint4()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int4", m_MemberName = "v", m_ElementInitializer = "rng.NextInt4()" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_uint", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int", m_MemberName = "result", m_ElementInitializer = "new int()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt()" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_uint2", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int2", m_MemberName = "result", m_ElementInitializer = "new int2()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint2", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt2()" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_uint3", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int3", m_MemberName = "result", m_ElementInitializer = "new int3()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint3", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt3()" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_uint4", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int4", m_MemberName = "result", m_ElementInitializer = "new int4()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint4", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt4()" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
             EndPerformanceTestCodeGen(str);
         }
 

--- a/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
+++ b/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
@@ -3694,26 +3694,98 @@ namespace Unity.Mathematics.Mathematics.CodeGen
             GeneratePerformanceTest(str, "asuint_float", new[]
             {
                 new PerformanceTestArrayArgument { m_ElementType = "uint", m_MemberName = "result", m_ElementInitializer = "new uint()" },
-                new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat(-1.0f, 1.0f)" },
-            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+                new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
 
             GeneratePerformanceTest(str, "asuint_float2", new[]
             {
                 new PerformanceTestArrayArgument { m_ElementType = "uint2", m_MemberName = "result", m_ElementInitializer = "new uint2()" },
-                new PerformanceTestArrayArgument { m_ElementType = "float2", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat2(-1.0f, 1.0f)" },
-            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+                new PerformanceTestArrayArgument { m_ElementType = "float2", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat2(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
 
             GeneratePerformanceTest(str, "asuint_float3", new[]
             {
                 new PerformanceTestArrayArgument { m_ElementType = "uint3", m_MemberName = "result", m_ElementInitializer = "new uint3()" },
-                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat3(-1.0f, 1.0f)" },
-            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat3(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
 
             GeneratePerformanceTest(str, "asuint_float4", new[]
             {
                 new PerformanceTestArrayArgument { m_ElementType = "uint4", m_MemberName = "result", m_ElementInitializer = "new uint4()" },
-                new PerformanceTestArrayArgument { m_ElementType = "float4", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat4(-1.0f, 1.0f)" },
-            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+                new PerformanceTestArrayArgument { m_ElementType = "float4", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat4(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_float", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int", m_MemberName = "result", m_ElementInitializer = "new int()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_float2", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int2", m_MemberName = "result", m_ElementInitializer = "new int2()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float2", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat2(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_float3", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int3", m_MemberName = "result", m_ElementInitializer = "new int3()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat3(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asint_float4", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "int4", m_MemberName = "result", m_ElementInitializer = "new int4()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float4", m_MemberName = "v", m_ElementInitializer = "rng.NextFloat4(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asint(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_uint", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "result", m_ElementInitializer = "new uint()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_uint2", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float2", m_MemberName = "result", m_ElementInitializer = "new uint2()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint2", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt2()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_uint3", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "result", m_ElementInitializer = "new uint3()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint3", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt3()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_uint4", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float4", m_MemberName = "result", m_ElementInitializer = "new uint4()" },
+                new PerformanceTestArrayArgument { m_ElementType = "uint4", m_MemberName = "v", m_ElementInitializer = "rng.NextUInt4()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_int", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "result", m_ElementInitializer = "new int()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int", m_MemberName = "v", m_ElementInitializer = "rng.NextInt()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_int2", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float2", m_MemberName = "result", m_ElementInitializer = "new int2()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int2", m_MemberName = "v", m_ElementInitializer = "rng.NextInt2()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_int3", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "result", m_ElementInitializer = "new int3()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int3", m_MemberName = "v", m_ElementInitializer = "rng.NextInt3()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asfloat_int4", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "float4", m_MemberName = "result", m_ElementInitializer = "new int4()" },
+                new PerformanceTestArrayArgument { m_ElementType = "int4", m_MemberName = "v", m_ElementInitializer = "rng.NextInt4()" },
+            }, "args.result[i] = math.asfloat(args.v[i]);", 400000);
 
             EndPerformanceTestCodeGen(str);
         }

--- a/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
+++ b/src/Unity.Mathematics.CodeGen/VectorGenerator.cs
@@ -3697,7 +3697,25 @@ namespace Unity.Mathematics.Mathematics.CodeGen
                 new PerformanceTestArrayArgument { m_ElementType = "float", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat(-1.0f, 1.0f)" },
             }, "args.result[i] = math.asuint(args.f[i]);", 400000);
 
-                EndPerformanceTestCodeGen(str);
+            GeneratePerformanceTest(str, "asuint_float2", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint2", m_MemberName = "result", m_ElementInitializer = "new uint2()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float2", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat2(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asuint_float3", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint3", m_MemberName = "result", m_ElementInitializer = "new uint3()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float3", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat3(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+
+            GeneratePerformanceTest(str, "asuint_float4", new[]
+            {
+                new PerformanceTestArrayArgument { m_ElementType = "uint4", m_MemberName = "result", m_ElementInitializer = "new uint4()" },
+                new PerformanceTestArrayArgument { m_ElementType = "float4", m_MemberName = "f", m_ElementInitializer = "rng.NextFloat4(-1.0f, 1.0f)" },
+            }, "args.result[i] = math.asuint(args.f[i]);", 400000);
+
+            EndPerformanceTestCodeGen(str);
         }
 
         public struct PerformanceTestArrayArgument

--- a/src/Unity.Mathematics.PerformanceTests/TestConversions.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestConversions.gen.cs
@@ -25,11 +25,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public quaternion* q;
                 public float3x3* f3x3;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -115,11 +117,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public quaternion* q;
                 public float3x3* f3x3;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -205,11 +209,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* f4;
                 public half4* h4;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -295,11 +301,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* f4;
                 public half4* h4;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -385,12 +393,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public quaternion* q;
                 public RigidTransform* rt;
                 public float3* pos;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -483,11 +493,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public quaternion* q;
                 public float4x4* f4x4;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -573,12 +585,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public quaternion* q;
                 public float4x4* f4x4;
                 public float3* f3;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -671,11 +685,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* f4;
                 public uint4* u4;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -761,11 +777,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* f4;
                 public uint4* u4;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     f4 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestFastInverse.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestFastInverse.gen.cs
@@ -25,10 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4x4* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -107,10 +109,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double4x4* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * iterations, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestHash.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestHash.gen.cs
@@ -25,11 +25,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -115,11 +117,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -205,11 +209,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -295,11 +301,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double2* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -385,11 +393,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double3* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -475,11 +485,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double4* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -565,11 +577,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2x2* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -655,11 +669,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3x3* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -745,11 +761,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4x4* v;
                 public uint* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -835,11 +853,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2x2* v;
                 public uint2* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -925,11 +945,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3x3* v;
                 public uint3* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1015,11 +1037,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4x4* v;
                 public uint4* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1105,11 +1129,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
                 public uint2* hash;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestInverse.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestInverse.gen.cs
@@ -25,10 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4x4* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -107,10 +109,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3x3* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -189,10 +193,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2x2* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -271,10 +277,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double4x4* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * iterations, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -353,10 +361,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double3x3* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (double3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3x3>() * iterations, UnsafeUtility.AlignOf<double3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -435,10 +445,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double2x2* m1;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (double2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2x2>() * iterations, UnsafeUtility.AlignOf<double2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -517,10 +529,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public quaternion* q;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     q = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
@@ -310,5 +310,281 @@ namespace Unity.Mathematics.PerformanceTests
             .Run();
             args.Dispose();
         }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asuint_float2
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public uint2* result;
+                public float2* f;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint2();
+                    }
+
+                    f = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        f[i] = rng.NextFloat2(-1.0f, 1.0f);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(f, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asuint(args.f[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asuint_float2_mono()
+        {
+            asuint_float2.TestFunction testFunction = asuint_float2.MonoTestFunction;
+            var args = new asuint_float2.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asuint_float2_burst()
+        {
+            FunctionPointer<asuint_float2.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_float2.TestFunction>(asuint_float2.BurstTestFunction);
+            var args = new asuint_float2.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asuint_float3
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public uint3* result;
+                public float3* f;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * iterations, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint3();
+                    }
+
+                    f = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        f[i] = rng.NextFloat3(-1.0f, 1.0f);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(f, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asuint(args.f[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asuint_float3_mono()
+        {
+            asuint_float3.TestFunction testFunction = asuint_float3.MonoTestFunction;
+            var args = new asuint_float3.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asuint_float3_burst()
+        {
+            FunctionPointer<asuint_float3.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_float3.TestFunction>(asuint_float3.BurstTestFunction);
+            var args = new asuint_float3.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asuint_float4
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public uint4* result;
+                public float4* f;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint4();
+                    }
+
+                    f = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        f[i] = rng.NextFloat4(-1.0f, 1.0f);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(f, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asuint(args.f[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asuint_float4_mono()
+        {
+            asuint_float4.TestFunction testFunction = asuint_float4.MonoTestFunction;
+            var args = new asuint_float4.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asuint_float4_burst()
+        {
+            FunctionPointer<asuint_float4.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_float4.TestFunction>(asuint_float4.BurstTestFunction);
+            var args = new asuint_float4.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
     }
 }

--- a/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
@@ -227,7 +227,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 public Random rng;
                 public uint* result;
-                public float* f;
+                public float* v;
 
                 public void Init()
                 {
@@ -238,10 +238,10 @@ namespace Unity.Mathematics.PerformanceTests
                         result[i] = new uint();
                     }
 
-                    f = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    v = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
-                        f[i] = rng.NextFloat(-1.0f, 1.0f);
+                        v[i] = rng.NextFloat(-1.0f, 1.0f);
                     }
 
                 }
@@ -249,7 +249,7 @@ namespace Unity.Mathematics.PerformanceTests
                 public void Dispose()
                 {
                     UnsafeUtility.Free(result, Allocator.Persistent);
-                    UnsafeUtility.Free(f, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
                 }
             }
 
@@ -257,7 +257,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.result[i] = math.asuint(args.f[i]);
+                    args.result[i] = math.asuint(args.v[i]);
                 }
             }
 
@@ -319,7 +319,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 public Random rng;
                 public uint2* result;
-                public float2* f;
+                public float2* v;
 
                 public void Init()
                 {
@@ -330,10 +330,10 @@ namespace Unity.Mathematics.PerformanceTests
                         result[i] = new uint2();
                     }
 
-                    f = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
-                        f[i] = rng.NextFloat2(-1.0f, 1.0f);
+                        v[i] = rng.NextFloat2(-1.0f, 1.0f);
                     }
 
                 }
@@ -341,7 +341,7 @@ namespace Unity.Mathematics.PerformanceTests
                 public void Dispose()
                 {
                     UnsafeUtility.Free(result, Allocator.Persistent);
-                    UnsafeUtility.Free(f, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
                 }
             }
 
@@ -349,7 +349,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.result[i] = math.asuint(args.f[i]);
+                    args.result[i] = math.asuint(args.v[i]);
                 }
             }
 
@@ -411,7 +411,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 public Random rng;
                 public uint3* result;
-                public float3* f;
+                public float3* v;
 
                 public void Init()
                 {
@@ -422,10 +422,10 @@ namespace Unity.Mathematics.PerformanceTests
                         result[i] = new uint3();
                     }
 
-                    f = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
-                        f[i] = rng.NextFloat3(-1.0f, 1.0f);
+                        v[i] = rng.NextFloat3(-1.0f, 1.0f);
                     }
 
                 }
@@ -433,7 +433,7 @@ namespace Unity.Mathematics.PerformanceTests
                 public void Dispose()
                 {
                     UnsafeUtility.Free(result, Allocator.Persistent);
-                    UnsafeUtility.Free(f, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
                 }
             }
 
@@ -441,7 +441,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.result[i] = math.asuint(args.f[i]);
+                    args.result[i] = math.asuint(args.v[i]);
                 }
             }
 
@@ -503,7 +503,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 public Random rng;
                 public uint4* result;
-                public float4* f;
+                public float4* v;
 
                 public void Init()
                 {
@@ -514,10 +514,10 @@ namespace Unity.Mathematics.PerformanceTests
                         result[i] = new uint4();
                     }
 
-                    f = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
-                        f[i] = rng.NextFloat4(-1.0f, 1.0f);
+                        v[i] = rng.NextFloat4(-1.0f, 1.0f);
                     }
 
                 }
@@ -525,7 +525,7 @@ namespace Unity.Mathematics.PerformanceTests
                 public void Dispose()
                 {
                     UnsafeUtility.Free(result, Allocator.Persistent);
-                    UnsafeUtility.Free(f, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
                 }
             }
 
@@ -533,7 +533,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.result[i] = math.asuint(args.f[i]);
+                    args.result[i] = math.asuint(args.v[i]);
                 }
             }
 
@@ -574,6 +574,1110 @@ namespace Unity.Mathematics.PerformanceTests
         {
             FunctionPointer<asuint_float4.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_float4.TestFunction>(asuint_float4.BurstTestFunction);
             var args = new asuint_float4.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_float
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int* result;
+                public float* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int>() * iterations, UnsafeUtility.AlignOf<int>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int();
+                    }
+
+                    v = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextFloat(-1.0f, 1.0f);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_float_mono()
+        {
+            asint_float.TestFunction testFunction = asint_float.MonoTestFunction;
+            var args = new asint_float.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_float_burst()
+        {
+            FunctionPointer<asint_float.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_float.TestFunction>(asint_float.BurstTestFunction);
+            var args = new asint_float.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_float2
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int2* result;
+                public float2* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int2>() * iterations, UnsafeUtility.AlignOf<int2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int2();
+                    }
+
+                    v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextFloat2(-1.0f, 1.0f);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_float2_mono()
+        {
+            asint_float2.TestFunction testFunction = asint_float2.MonoTestFunction;
+            var args = new asint_float2.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_float2_burst()
+        {
+            FunctionPointer<asint_float2.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_float2.TestFunction>(asint_float2.BurstTestFunction);
+            var args = new asint_float2.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_float3
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int3* result;
+                public float3* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int3>() * iterations, UnsafeUtility.AlignOf<int3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int3();
+                    }
+
+                    v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextFloat3(-1.0f, 1.0f);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_float3_mono()
+        {
+            asint_float3.TestFunction testFunction = asint_float3.MonoTestFunction;
+            var args = new asint_float3.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_float3_burst()
+        {
+            FunctionPointer<asint_float3.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_float3.TestFunction>(asint_float3.BurstTestFunction);
+            var args = new asint_float3.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_float4
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int4* result;
+                public float4* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int4>() * iterations, UnsafeUtility.AlignOf<int4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int4();
+                    }
+
+                    v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextFloat4(-1.0f, 1.0f);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_float4_mono()
+        {
+            asint_float4.TestFunction testFunction = asint_float4.MonoTestFunction;
+            var args = new asint_float4.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_float4_burst()
+        {
+            FunctionPointer<asint_float4.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_float4.TestFunction>(asint_float4.BurstTestFunction);
+            var args = new asint_float4.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_uint
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float* result;
+                public uint* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint();
+                    }
+
+                    v = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_uint_mono()
+        {
+            asfloat_uint.TestFunction testFunction = asfloat_uint.MonoTestFunction;
+            var args = new asfloat_uint.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_uint_burst()
+        {
+            FunctionPointer<asfloat_uint.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_uint.TestFunction>(asfloat_uint.BurstTestFunction);
+            var args = new asfloat_uint.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_uint2
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float2* result;
+                public uint2* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint2();
+                    }
+
+                    v = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt2();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_uint2_mono()
+        {
+            asfloat_uint2.TestFunction testFunction = asfloat_uint2.MonoTestFunction;
+            var args = new asfloat_uint2.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_uint2_burst()
+        {
+            FunctionPointer<asfloat_uint2.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_uint2.TestFunction>(asfloat_uint2.BurstTestFunction);
+            var args = new asfloat_uint2.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_uint3
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float3* result;
+                public uint3* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint3();
+                    }
+
+                    v = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * iterations, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt3();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_uint3_mono()
+        {
+            asfloat_uint3.TestFunction testFunction = asfloat_uint3.MonoTestFunction;
+            var args = new asfloat_uint3.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_uint3_burst()
+        {
+            FunctionPointer<asfloat_uint3.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_uint3.TestFunction>(asfloat_uint3.BurstTestFunction);
+            var args = new asfloat_uint3.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_uint4
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float4* result;
+                public uint4* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint4();
+                    }
+
+                    v = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt4();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_uint4_mono()
+        {
+            asfloat_uint4.TestFunction testFunction = asfloat_uint4.MonoTestFunction;
+            var args = new asfloat_uint4.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_uint4_burst()
+        {
+            FunctionPointer<asfloat_uint4.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_uint4.TestFunction>(asfloat_uint4.BurstTestFunction);
+            var args = new asfloat_uint4.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_int
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float* result;
+                public int* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int();
+                    }
+
+                    v = (int*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int>() * iterations, UnsafeUtility.AlignOf<int>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_int_mono()
+        {
+            asfloat_int.TestFunction testFunction = asfloat_int.MonoTestFunction;
+            var args = new asfloat_int.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_int_burst()
+        {
+            FunctionPointer<asfloat_int.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_int.TestFunction>(asfloat_int.BurstTestFunction);
+            var args = new asfloat_int.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_int2
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float2* result;
+                public int2* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int2();
+                    }
+
+                    v = (int2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int2>() * iterations, UnsafeUtility.AlignOf<int2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt2();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_int2_mono()
+        {
+            asfloat_int2.TestFunction testFunction = asfloat_int2.MonoTestFunction;
+            var args = new asfloat_int2.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_int2_burst()
+        {
+            FunctionPointer<asfloat_int2.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_int2.TestFunction>(asfloat_int2.BurstTestFunction);
+            var args = new asfloat_int2.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_int3
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float3* result;
+                public int3* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int3();
+                    }
+
+                    v = (int3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int3>() * iterations, UnsafeUtility.AlignOf<int3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt3();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_int3_mono()
+        {
+            asfloat_int3.TestFunction testFunction = asfloat_int3.MonoTestFunction;
+            var args = new asfloat_int3.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_int3_burst()
+        {
+            FunctionPointer<asfloat_int3.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_int3.TestFunction>(asfloat_int3.BurstTestFunction);
+            var args = new asfloat_int3.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asfloat_int4
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public float4* result;
+                public int4* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int4();
+                    }
+
+                    v = (int4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int4>() * iterations, UnsafeUtility.AlignOf<int4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt4();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asfloat(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asfloat_int4_mono()
+        {
+            asfloat_int4.TestFunction testFunction = asfloat_int4.MonoTestFunction;
+            var args = new asfloat_int4.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asfloat_int4_burst()
+        {
+            FunctionPointer<asfloat_int4.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asfloat_int4.TestFunction>(asfloat_int4.BurstTestFunction);
+            var args = new asfloat_int4.Arguments();
             args.Init();
 
             var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>

--- a/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
@@ -1690,5 +1690,373 @@ namespace Unity.Mathematics.PerformanceTests
             .Run();
             args.Dispose();
         }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asdouble_ulong
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public double* result;
+                public ulong* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (double*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double>() * iterations, UnsafeUtility.AlignOf<double>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new double();
+                    }
+
+                    v = (ulong*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<ulong>() * iterations, UnsafeUtility.AlignOf<ulong>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asdouble(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asdouble_ulong_mono()
+        {
+            asdouble_ulong.TestFunction testFunction = asdouble_ulong.MonoTestFunction;
+            var args = new asdouble_ulong.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asdouble_ulong_burst()
+        {
+            FunctionPointer<asdouble_ulong.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asdouble_ulong.TestFunction>(asdouble_ulong.BurstTestFunction);
+            var args = new asdouble_ulong.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asdouble_long
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public double* result;
+                public long* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (double*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double>() * iterations, UnsafeUtility.AlignOf<double>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new double();
+                    }
+
+                    v = (long*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<long>() * iterations, UnsafeUtility.AlignOf<long>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asdouble(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asdouble_long_mono()
+        {
+            asdouble_long.TestFunction testFunction = asdouble_long.MonoTestFunction;
+            var args = new asdouble_long.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asdouble_long_burst()
+        {
+            FunctionPointer<asdouble_long.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asdouble_long.TestFunction>(asdouble_long.BurstTestFunction);
+            var args = new asdouble_long.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class aslong_double
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public long* result;
+                public double* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (long*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<long>() * iterations, UnsafeUtility.AlignOf<long>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new long();
+                    }
+
+                    v = (double*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double>() * iterations, UnsafeUtility.AlignOf<double>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextDouble(-1.0, 1.0);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.aslong(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void aslong_double_mono()
+        {
+            aslong_double.TestFunction testFunction = aslong_double.MonoTestFunction;
+            var args = new aslong_double.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void aslong_double_burst()
+        {
+            FunctionPointer<aslong_double.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<aslong_double.TestFunction>(aslong_double.BurstTestFunction);
+            var args = new aslong_double.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asulong_double
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public ulong* result;
+                public double* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (ulong*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<ulong>() * iterations, UnsafeUtility.AlignOf<ulong>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new ulong();
+                    }
+
+                    v = (double*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double>() * iterations, UnsafeUtility.AlignOf<double>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextDouble(-1.0, 1.0);
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asulong(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asulong_double_mono()
+        {
+            asulong_double.TestFunction testFunction = asulong_double.MonoTestFunction;
+            var args = new asulong_double.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asulong_double_burst()
+        {
+            FunctionPointer<asulong_double.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asulong_double.TestFunction>(asulong_double.BurstTestFunction);
+            var args = new asulong_double.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
     }
 }

--- a/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMath.gen.cs
@@ -2058,5 +2058,741 @@ namespace Unity.Mathematics.PerformanceTests
             .Run();
             args.Dispose();
         }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asuint_int
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public uint* result;
+                public int* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint();
+                    }
+
+                    v = (int*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int>() * iterations, UnsafeUtility.AlignOf<int>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asuint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asuint_int_mono()
+        {
+            asuint_int.TestFunction testFunction = asuint_int.MonoTestFunction;
+            var args = new asuint_int.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asuint_int_burst()
+        {
+            FunctionPointer<asuint_int.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_int.TestFunction>(asuint_int.BurstTestFunction);
+            var args = new asuint_int.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asuint_int2
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public uint2* result;
+                public int2* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint2();
+                    }
+
+                    v = (int2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int2>() * iterations, UnsafeUtility.AlignOf<int2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt2();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asuint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asuint_int2_mono()
+        {
+            asuint_int2.TestFunction testFunction = asuint_int2.MonoTestFunction;
+            var args = new asuint_int2.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asuint_int2_burst()
+        {
+            FunctionPointer<asuint_int2.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_int2.TestFunction>(asuint_int2.BurstTestFunction);
+            var args = new asuint_int2.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asuint_int3
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public uint3* result;
+                public int3* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * iterations, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint3();
+                    }
+
+                    v = (int3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int3>() * iterations, UnsafeUtility.AlignOf<int3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt3();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asuint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asuint_int3_mono()
+        {
+            asuint_int3.TestFunction testFunction = asuint_int3.MonoTestFunction;
+            var args = new asuint_int3.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asuint_int3_burst()
+        {
+            FunctionPointer<asuint_int3.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_int3.TestFunction>(asuint_int3.BurstTestFunction);
+            var args = new asuint_int3.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asuint_int4
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public uint4* result;
+                public int4* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new uint4();
+                    }
+
+                    v = (int4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int4>() * iterations, UnsafeUtility.AlignOf<int4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextInt4();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asuint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asuint_int4_mono()
+        {
+            asuint_int4.TestFunction testFunction = asuint_int4.MonoTestFunction;
+            var args = new asuint_int4.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asuint_int4_burst()
+        {
+            FunctionPointer<asuint_int4.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asuint_int4.TestFunction>(asuint_int4.BurstTestFunction);
+            var args = new asuint_int4.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_uint
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int* result;
+                public uint* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int>() * iterations, UnsafeUtility.AlignOf<int>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int();
+                    }
+
+                    v = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_uint_mono()
+        {
+            asint_uint.TestFunction testFunction = asint_uint.MonoTestFunction;
+            var args = new asint_uint.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_uint_burst()
+        {
+            FunctionPointer<asint_uint.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_uint.TestFunction>(asint_uint.BurstTestFunction);
+            var args = new asint_uint.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_uint2
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int2* result;
+                public uint2* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int2>() * iterations, UnsafeUtility.AlignOf<int2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int2();
+                    }
+
+                    v = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt2();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_uint2_mono()
+        {
+            asint_uint2.TestFunction testFunction = asint_uint2.MonoTestFunction;
+            var args = new asint_uint2.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_uint2_burst()
+        {
+            FunctionPointer<asint_uint2.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_uint2.TestFunction>(asint_uint2.BurstTestFunction);
+            var args = new asint_uint2.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_uint3
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int3* result;
+                public uint3* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int3>() * iterations, UnsafeUtility.AlignOf<int3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int3();
+                    }
+
+                    v = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * iterations, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt3();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_uint3_mono()
+        {
+            asint_uint3.TestFunction testFunction = asint_uint3.MonoTestFunction;
+            var args = new asint_uint3.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_uint3_burst()
+        {
+            FunctionPointer<asint_uint3.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_uint3.TestFunction>(asint_uint3.BurstTestFunction);
+            var args = new asint_uint3.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+        [BurstCompile(CompileSynchronously = true)]
+        public unsafe class asint_uint4
+        {
+            public const int iterations = 400000;
+
+            public struct Arguments : IDisposable
+            {
+                public Random rng;
+                public int4* result;
+                public uint4* v;
+
+                public void Init()
+                {
+                    rng = new Random(1);
+                    result = (int4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<int4>() * iterations, UnsafeUtility.AlignOf<int4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        result[i] = new int4();
+                    }
+
+                    v = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
+                    for (int i = 0; i < iterations; ++i)
+                    {
+                        v[i] = rng.NextUInt4();
+                    }
+
+                }
+
+                public void Dispose()
+                {
+                    UnsafeUtility.Free(result, Allocator.Persistent);
+                    UnsafeUtility.Free(v, Allocator.Persistent);
+                }
+            }
+
+            public static void CommonTestFunction(ref Arguments args)
+            {
+                for (int i = 0; i < iterations; ++i)
+                {
+                    args.result[i] = math.asint(args.v[i]);
+                }
+            }
+
+            public static void MonoTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            [BurstCompile(CompileSynchronously = true)]
+            public static void BurstTestFunction(ref Arguments args)
+            {
+                CommonTestFunction(ref args);
+            }
+
+            public delegate void TestFunction(ref Arguments args);
+        }
+
+        [Test, Performance]
+        public void asint_uint4_mono()
+        {
+            asint_uint4.TestFunction testFunction = asint_uint4.MonoTestFunction;
+            var args = new asint_uint4.Arguments();
+            args.Init();
+
+            var monoSampleGroup = new SampleGroup("Mono", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(monoSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
+
+        [Test, Performance]
+        public void asint_uint4_burst()
+        {
+            FunctionPointer<asint_uint4.TestFunction> testFunction = BurstCompiler.CompileFunctionPointer<asint_uint4.TestFunction>(asint_uint4.BurstTestFunction);
+            var args = new asint_uint4.Arguments();
+            args.Init();
+
+            var burstSampleGroup = new SampleGroup("Burst", SampleUnit.Microsecond);            Measure.Method(() =>
+            {
+                testFunction.Invoke(ref args);
+            })
+            .SampleGroup(burstSampleGroup)
+            .WarmupCount(1)
+            .MeasurementCount(10)
+            .Run();
+            args.Dispose();
+        }
     }
 }

--- a/src/Unity.Mathematics.PerformanceTests/TestMinMaxAABB.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMinMaxAABB.gen.cs
@@ -25,10 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public Geometry.MinMaxAABB* a;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     a = (Geometry.MinMaxAABB*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Geometry.MinMaxAABB>() * iterations, UnsafeUtility.AlignOf<Geometry.MinMaxAABB>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -107,10 +109,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public Geometry.MinMaxAABB* a;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     a = (Geometry.MinMaxAABB*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Geometry.MinMaxAABB>() * iterations, UnsafeUtility.AlignOf<Geometry.MinMaxAABB>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestMul.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestMul.gen.cs
@@ -25,11 +25,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4x4* m1;
                 public float4x4* m2;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -115,11 +117,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4x4* m1;
                 public float4* m2;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -205,11 +209,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public quaternion* q1;
                 public quaternion* q2;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     q1 = (quaternion*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<quaternion>() * iterations, UnsafeUtility.AlignOf<quaternion>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -295,11 +301,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3x3* m1;
                 public float3x3* m2;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -385,11 +393,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2x2* m1;
                 public float2x2* m2;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -475,11 +485,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3x3* m1;
                 public float3* m2;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -565,11 +577,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2x2* m1;
                 public float2* m2;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m1 = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestNoise.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestNoise.gen.cs
@@ -25,10 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -107,10 +109,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -189,10 +193,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -271,11 +277,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
                 public float3* gradient;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -361,10 +369,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -443,10 +453,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -525,10 +537,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -607,10 +621,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -689,10 +705,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -771,10 +789,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -853,10 +873,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -935,10 +957,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1017,10 +1041,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1099,10 +1125,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1181,10 +1209,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1263,10 +1293,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1345,10 +1377,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1427,10 +1461,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestNormalize.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestNormalize.gen.cs
@@ -25,10 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -107,10 +109,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -189,10 +193,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -271,10 +277,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double4* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -353,10 +361,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -435,10 +445,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -517,10 +529,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -599,10 +613,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -681,10 +697,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -763,10 +781,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double4* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -845,10 +865,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double3* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -927,10 +949,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double2* v;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestPlane.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestPlane.gen.cs
@@ -25,10 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public Plane* p;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     p = (Plane*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Plane>() * iterations, UnsafeUtility.AlignOf<Plane>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestRandom.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestRandom.gen.cs
@@ -25,17 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public uint* u;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     u = (uint*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint>() * iterations, UnsafeUtility.AlignOf<uint>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -46,7 +41,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(u, Allocator.Persistent);
                 }
             }
@@ -55,7 +49,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.u[i] = args.rng[i].NextUInt();
+                    args.u[i] = args.rng.NextUInt();
                 }
             }
 
@@ -115,17 +109,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public uint2* u;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     u = (uint2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint2>() * iterations, UnsafeUtility.AlignOf<uint2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -136,7 +125,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(u, Allocator.Persistent);
                 }
             }
@@ -145,7 +133,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.u[i] = args.rng[i].NextUInt2();
+                    args.u[i] = args.rng.NextUInt2();
                 }
             }
 
@@ -205,17 +193,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public uint3* u;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     u = (uint3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint3>() * iterations, UnsafeUtility.AlignOf<uint3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -226,7 +209,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(u, Allocator.Persistent);
                 }
             }
@@ -235,7 +217,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.u[i] = args.rng[i].NextUInt3();
+                    args.u[i] = args.rng.NextUInt3();
                 }
             }
 
@@ -295,17 +277,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public uint4* u;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     u = (uint4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<uint4>() * iterations, UnsafeUtility.AlignOf<uint4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -316,7 +293,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(u, Allocator.Persistent);
                 }
             }
@@ -325,7 +301,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.u[i] = args.rng[i].NextUInt4();
+                    args.u[i] = args.rng.NextUInt4();
                 }
             }
 
@@ -385,17 +361,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public float* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -406,7 +377,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -415,7 +385,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextFloat();
+                    args.f[i] = args.rng.NextFloat();
                 }
             }
 
@@ -475,17 +445,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public float2* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -496,7 +461,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -505,7 +469,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextFloat2();
+                    args.f[i] = args.rng.NextFloat2();
                 }
             }
 
@@ -565,17 +529,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public float3* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -586,7 +545,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -595,7 +553,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextFloat3();
+                    args.f[i] = args.rng.NextFloat3();
                 }
             }
 
@@ -655,17 +613,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public float4* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -676,7 +629,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -685,7 +637,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextFloat4();
+                    args.f[i] = args.rng.NextFloat4();
                 }
             }
 
@@ -745,17 +697,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public double* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (double*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double>() * iterations, UnsafeUtility.AlignOf<double>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -766,7 +713,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -775,7 +721,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextDouble();
+                    args.f[i] = args.rng.NextDouble();
                 }
             }
 
@@ -835,17 +781,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public double2* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (double2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2>() * iterations, UnsafeUtility.AlignOf<double2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -856,7 +797,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -865,7 +805,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextDouble2();
+                    args.f[i] = args.rng.NextDouble2();
                 }
             }
 
@@ -925,17 +865,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public double3* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (double3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3>() * iterations, UnsafeUtility.AlignOf<double3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -946,7 +881,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -955,7 +889,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextDouble3();
+                    args.f[i] = args.rng.NextDouble3();
                 }
             }
 
@@ -1015,17 +949,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
-                public Random* rng;
+                public Random rng;
                 public double4* f;
 
                 public void Init()
                 {
-                    rng = (Random*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<Random>() * iterations, UnsafeUtility.AlignOf<Random>(), Allocator.Persistent);
-                    for (int i = 0; i < iterations; ++i)
-                    {
-                        rng[i] = new Unity.Mathematics.Random(1);
-                    }
-
+                    rng = new Random(1);
                     f = (double4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4>() * iterations, UnsafeUtility.AlignOf<double4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -1036,7 +965,6 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Dispose()
                 {
-                    UnsafeUtility.Free(rng, Allocator.Persistent);
                     UnsafeUtility.Free(f, Allocator.Persistent);
                 }
             }
@@ -1045,7 +973,7 @@ namespace Unity.Mathematics.PerformanceTests
             {
                 for (int i = 0; i < iterations; ++i)
                 {
-                    args.f[i] = args.rng[i].NextDouble4();
+                    args.f[i] = args.rng.NextDouble4();
                 }
             }
 

--- a/src/Unity.Mathematics.PerformanceTests/TestRotation.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestRotation.gen.cs
@@ -25,11 +25,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
                 public float4x4* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -115,11 +117,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
                 public float3x3* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -205,12 +209,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
                 public float4x4* m;
                 public float* angle;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -303,12 +309,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v;
                 public float3x3* m;
                 public float* angle;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -401,12 +409,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* forward;
                 public float3* up;
                 public float3x3* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     forward = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -499,12 +509,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* forward;
                 public float3* up;
                 public float3x3* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     forward = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -597,6 +609,7 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* eye;
                 public float3* target;
                 public float3* up;
@@ -604,6 +617,7 @@ namespace Unity.Mathematics.PerformanceTests
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     eye = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestShuffle.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestShuffle.gen.cs
@@ -25,12 +25,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* v1;
                 public float2* v2;
                 public float2* result;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v1 = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -123,12 +125,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* v1;
                 public float3* v2;
                 public float3* result;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v1 = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -221,12 +225,14 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* v1;
                 public float4* v2;
                 public float4* result;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     v1 = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestTranspose.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestTranspose.gen.cs
@@ -25,10 +25,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4x4* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m = (float4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4x4>() * iterations, UnsafeUtility.AlignOf<float4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -107,10 +109,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3x3* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m = (float3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3x3>() * iterations, UnsafeUtility.AlignOf<float3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -189,10 +193,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2x2* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m = (float2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2x2>() * iterations, UnsafeUtility.AlignOf<float2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -271,10 +277,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double4x4* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m = (double4x4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double4x4>() * iterations, UnsafeUtility.AlignOf<double4x4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -353,10 +361,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double3x3* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m = (double3x3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double3x3>() * iterations, UnsafeUtility.AlignOf<double3x3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -435,10 +445,12 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public double2x2* m;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     m = (double2x2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<double2x2>() * iterations, UnsafeUtility.AlignOf<double2x2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics.PerformanceTests/TestTrig.gen.cs
+++ b/src/Unity.Mathematics.PerformanceTests/TestTrig.gen.cs
@@ -25,11 +25,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float* sin;
                 public float* cos;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     sin = (float*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float>() * iterations, UnsafeUtility.AlignOf<float>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -115,11 +117,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float2* sin;
                 public float2* cos;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     sin = (float2*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float2>() * iterations, UnsafeUtility.AlignOf<float2>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -205,11 +209,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float3* sin;
                 public float3* cos;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     sin = (float3*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float3>() * iterations, UnsafeUtility.AlignOf<float3>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {
@@ -295,11 +301,13 @@ namespace Unity.Mathematics.PerformanceTests
 
             public struct Arguments : IDisposable
             {
+                public Random rng;
                 public float4* sin;
                 public float4* cos;
 
                 public void Init()
                 {
+                    rng = new Random(1);
                     sin = (float4*)UnsafeUtility.Malloc(UnsafeUtility.SizeOf<float4>() * iterations, UnsafeUtility.AlignOf<float4>(), Allocator.Persistent);
                     for (int i = 0; i < iterations; ++i)
                     {

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -225,26 +225,49 @@ namespace Unity.Mathematics
         /// <param name="x">The int bits to copy.</param>
         /// <returns>The uint with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint asuint(int x) { return (uint)x; }
+        public static uint asuint(int x)
+        {
+            unsafe
+            {
+                return *(uint*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of an int2 as a uint2.</summary>
         /// <param name="x">The int2 bits to copy.</param>
         /// <returns>The uint2 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint2 asuint(int2 x) { return uint2((uint)x.x, (uint)x.y); }
+        public static uint2 asuint(int2 x)
+        {
+            unsafe
+            {
+                return *(uint2*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of an int3 as a uint3.</summary>
         /// <param name="x">The int3 bits to copy.</param>
         /// <returns>The uint3 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint3 asuint(int3 x) { return uint3((uint)x.x, (uint)x.y, (uint)x.z); }
+        public static uint3 asuint(int3 x)
+        {
+            unsafe
+            {
+                return *(uint3*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of an int4 as a uint4.</summary>
         /// <param name="x">The int4 bits to copy.</param>
         /// <returns>The uint4 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint4 asuint(int4 x) { return uint4((uint)x.x, (uint)x.y, (uint)x.z, (uint)x.w); }
-
+        public static uint4 asuint(int4 x)
+        {
+            unsafe
+            {
+                return *(uint4*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a float as a uint.</summary>
         /// <param name="x">The float bits to copy.</param>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -248,13 +248,7 @@ namespace Unity.Mathematics
         /// <param name="x">The int bits to copy.</param>
         /// <returns>The uint with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint asuint(int x)
-        {
-            unsafe
-            {
-                return *(uint*)&x;
-            }
-        }
+        public static uint asuint(int x) { return (uint)x; }
 
         /// <summary>Returns the bit pattern of an int2 as a uint2.</summary>
         /// <param name="x">The int2 bits to copy.</param>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -401,25 +401,49 @@ namespace Unity.Mathematics
         /// <param name="x">The uint bits to copy.</param>
         /// <returns>The float with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float  asfloat(uint x) { return asfloat((int)x); }
+        public static float asfloat(uint x)
+        {
+            unsafe
+            {
+                return *(float*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a uint2 as a float2.</summary>
         /// <param name="x">The uint2 bits to copy.</param>
         /// <returns>The float2 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 asfloat(uint2 x) { return float2(asfloat(x.x), asfloat(x.y)); }
+        public static float2 asfloat(uint2 x)
+        {
+            unsafe
+            {
+                return *(float2*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a uint3 as a float3.</summary>
         /// <param name="x">The uint3 bits to copy.</param>
         /// <returns>The float3 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 asfloat(uint3 x) { return float3(asfloat(x.x), asfloat(x.y), asfloat(x.z)); }
+        public static float3 asfloat(uint3 x)
+        {
+            unsafe
+            {
+                return *(float3*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a uint4 as a float4.</summary>
         /// <param name="x">The uint4 bits to copy.</param>
         /// <returns>The float4 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 asfloat(uint4 x) { return float4(asfloat(x.x), asfloat(x.y), asfloat(x.z), asfloat(x.w)); }
+        public static float4 asfloat(uint4 x)
+        {
+            unsafe
+            {
+                return *(float4*)&x;
+            }
+        }
 
         /// <summary>
         /// Returns a bitmask representation of a bool4. Storing one 1 bit per component

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -152,26 +152,49 @@ namespace Unity.Mathematics
         /// <param name="x">The uint bits to copy.</param>
         /// <returns>The int with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int asint(uint x) { return (int)x; }
+        public static int asint(uint x)
+        {
+            unsafe
+            {
+                return *(int*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a uint2 as an int2.</summary>
         /// <param name="x">The uint2 bits to copy.</param>
         /// <returns>The int2 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int2 asint(uint2 x) { return int2((int)x.x, (int)x.y); }
+        public static int2 asint(uint2 x)
+        {
+            unsafe
+            {
+                return *(int2*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a uint3 as an int3.</summary>
         /// <param name="x">The uint3 bits to copy.</param>
         /// <returns>The int3 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int3 asint(uint3 x) { return int3((int)x.x, (int)x.y, (int)x.z); }
+        public static int3 asint(uint3 x)
+        {
+            unsafe
+            {
+                return *(int3*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a uint4 as an int4.</summary>
         /// <param name="x">The uint4 bits to copy.</param>
         /// <returns>The int4 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int4 asint(uint4 x) { return int4((int)x.x, (int)x.y, (int)x.z, (int)x.w); }
-
+        public static int4 asint(uint4 x)
+        {
+            unsafe
+            {
+                return *(int4*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a float as an int.</summary>
         /// <param name="x">The float bits to copy.</param>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -352,12 +352,11 @@ namespace Unity.Mathematics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long aslong(double x)
         {
-            LongDoubleUnion u;
-            u.longValue = 0;
-            u.doubleValue = x;
-            return u.longValue;
+            unsafe
+            {
+                return *(long*)&x;
+            }
         }
-
 
         /// <summary>Returns the bit pattern of a long as a ulong.</summary>
         /// <param name="x">The long bits to copy.</param>
@@ -369,8 +368,13 @@ namespace Unity.Mathematics
         /// <param name="x">The double bits to copy.</param>
         /// <returns>The ulong with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong asulong(double x) { return (ulong) aslong(x); }
-
+        public static ulong asulong(double x)
+        {
+            unsafe
+            {
+                return *(ulong*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of an int as a float.</summary>
         /// <param name="x">The int bits to copy.</param>
@@ -495,19 +499,23 @@ namespace Unity.Mathematics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double asdouble(long x)
         {
-            LongDoubleUnion u;
-            u.doubleValue = 0;
-            u.longValue = x;
-            return u.doubleValue;
+            unsafe
+            {
+                return *(double*)&x;
+            }
         }
-
 
         /// <summary>Returns the bit pattern of a ulong as a double.</summary>
         /// <param name="x">The ulong bits to copy.</param>
         /// <returns>The double with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double asdouble(ulong x) { return asdouble((long)x); }
-
+        public static double asdouble(ulong x)
+        {
+            unsafe
+            {
+                return *(double*)&x;
+            }
+        }
 
         /// <summary>Returns true if the input float is a finite floating point value, false otherwise.</summary>
         /// <param name="x">The float value to test.</param>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -177,31 +177,49 @@ namespace Unity.Mathematics
         /// <param name="x">The float bits to copy.</param>
         /// <returns>The int with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int asint(float x) {
-            IntFloatUnion u;
-            u.intValue = 0;
-            u.floatValue = x;
-            return u.intValue;
+        public static int asint(float x)
+        {
+            unsafe
+            {
+                return *(int*)&x;
+            }
         }
 
         /// <summary>Returns the bit pattern of a float2 as an int2.</summary>
         /// <param name="x">The float2 bits to copy.</param>
         /// <returns>The int2 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int2 asint(float2 x) { return int2(asint(x.x), asint(x.y)); }
+        public static int2 asint(float2 x)
+        {
+            unsafe
+            {
+                return *(int2*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a float3 as an int3.</summary>
         /// <param name="x">The float3 bits to copy.</param>
         /// <returns>The int3 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int3 asint(float3 x) { return int3(asint(x.x), asint(x.y), asint(x.z)); }
+        public static int3 asint(float3 x)
+        {
+            unsafe
+            {
+                return *(int3*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a float4 as an int4.</summary>
         /// <param name="x">The float4 bits to copy.</param>
         /// <returns>The int4 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int4 asint(float4 x) { return int4(asint(x.x), asint(x.y), asint(x.z), asint(x.w)); }
-
+        public static int4 asint(float4 x)
+        {
+            unsafe
+            {
+                return *(int4*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of an int as a uint.</summary>
         /// <param name="x">The int bits to copy.</param>
@@ -291,31 +309,47 @@ namespace Unity.Mathematics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float asfloat(int x)
         {
-            IntFloatUnion u;
-            u.floatValue = 0;
-            u.intValue = x;
-
-            return u.floatValue;
+            unsafe
+            {
+                return *(float*)&x;
+            }
         }
 
         /// <summary>Returns the bit pattern of an int2 as a float2.</summary>
         /// <param name="x">The int2 bits to copy.</param>
         /// <returns>The float2 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 asfloat(int2 x) { return float2(asfloat(x.x), asfloat(x.y)); }
+        public static float2 asfloat(int2 x)
+        {
+            unsafe
+            {
+                return *(float2*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of an int3 as a float3.</summary>
         /// <param name="x">The int3 bits to copy.</param>
         /// <returns>The float3 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 asfloat(int3 x) { return float3(asfloat(x.x), asfloat(x.y), asfloat(x.z)); }
+        public static float3 asfloat(int3 x)
+        {
+            unsafe
+            {
+                return *(float3*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of an int4 as a float4.</summary>
         /// <param name="x">The int4 bits to copy.</param>
         /// <returns>The float4 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 asfloat(int4 x) { return float4(asfloat(x.x), asfloat(x.y), asfloat(x.z), asfloat(x.w)); }
-
+        public static float4 asfloat(int4 x)
+        {
+            unsafe
+            {
+                return *(float4*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a uint as a float.</summary>
         /// <param name="x">The uint bits to copy.</param>
@@ -6646,15 +6680,6 @@ namespace Unity.Mathematics
         internal static uint3 fold_to_uint(double3 x) { return uint3(fold_to_uint(x.x), fold_to_uint(x.y), fold_to_uint(x.z)); }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint4 fold_to_uint(double4 x) { return uint4(fold_to_uint(x.x), fold_to_uint(x.y), fold_to_uint(x.z), fold_to_uint(x.w)); }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct IntFloatUnion
-        {
-            [FieldOffset(0)]
-            public int intValue;
-            [FieldOffset(0)]
-            public float floatValue;
-        }
 
         [StructLayout(LayoutKind.Explicit)]
         internal struct LongDoubleUnion

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -250,26 +250,49 @@ namespace Unity.Mathematics
         /// <param name="x">The float bits to copy.</param>
         /// <returns>The uint with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint asuint(float x) { return (uint)asint(x); }
+        public static uint asuint(float x)
+        {
+            unsafe
+            {
+                return *(uint*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a float2 as a uint2.</summary>
         /// <param name="x">The float2 bits to copy.</param>
         /// <returns>The uint2 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint2 asuint(float2 x) { return uint2(asuint(x.x), asuint(x.y)); }
+        public static uint2 asuint(float2 x)
+        {
+            unsafe
+            {
+                return *(uint2*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a float3 as a uint3.</summary>
         /// <param name="x">The float3 bits to copy.</param>
         /// <returns>The uint3 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint3 asuint(float3 x) { return uint3(asuint(x.x), asuint(x.y), asuint(x.z)); }
+        public static uint3 asuint(float3 x)
+        {
+            unsafe
+            {
+                return *(uint3*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a float4 as a uint4.</summary>
         /// <param name="x">The float4 bits to copy.</param>
         /// <returns>The uint4 with the same bit pattern as the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint4 asuint(float4 x) { return uint4(asuint(x.x), asuint(x.y), asuint(x.z), asuint(x.w)); }
-
+        public static uint4 asuint(float4 x)
+        {
+            unsafe
+            {
+                return *(uint4*)&x;
+            }
+        }
 
         /// <summary>Returns the bit pattern of a ulong as a long.</summary>
         /// <param name="x">The ulong bits to copy.</param>


### PR DESCRIPTION
DOTS-5396

While working on #201 I noticed that `chgsign` was pretty slow without burst so I investigated more carefully. With the help of https://github.com/sschoener/unity-asm-explorer-package from @sschoener, I was finally able to see what was going on. `chgsign` makes use of `asfloat` and `asuint` to manipulate the sign bit directly but mono (without burst) struggles with these methods because of the use of `IntFloatUnion` which forces it to initialize all fields to zero prior to doing any work. It also forces excessive stack traffic and conversion from single -> double -> single. Here is an example of `asfloat(uint4)` before this change:

```
public static Unity.Mathematics.float4 asfloat(Unity.Mathematics.uint4 x)
Address: 00000001782306F0
Code Size in Bytes: 1046
Debug mode: enabled

00000001782306f0 48 81 ec c8 00 00 00           sub rsp, 0xc8
00000001782306f7 48 89 3c 24                    mov [rsp], rdi
00000001782306fb 48 89 b4 24 b8 00 00 00        mov [rsp+0xb8], rsi
0000000178230703 48 89 94 24 c0 00 00 00        mov [rsp+0xc0], rdx
000000017823070b 48 63 84 24 b8 00 00 00        movsxd rax, dword [rsp+0xb8]
0000000178230713 89 84 24 98 00 00 00           mov [rsp+0x98], eax
000000017823071a 48 63 84 24 bc 00 00 00        movsxd rax, dword [rsp+0xbc]
0000000178230722 89 84 24 9c 00 00 00           mov [rsp+0x9c], eax
0000000178230729 48 63 84 24 c0 00 00 00        movsxd rax, dword [rsp+0xc0]
0000000178230731 89 84 24 a0 00 00 00           mov [rsp+0xa0], eax
0000000178230738 48 63 84 24 c4 00 00 00        movsxd rax, dword [rsp+0xc4]
0000000178230740 89 84 24 a4 00 00 00           mov [rsp+0xa4], eax
0000000178230747 8b 84 24 98 00 00 00           mov eax, [rsp+0x98]
000000017823074e c7 84 24 90 00 00 00 00 00 00 00  mov dword [rsp+0x90], 0x0
0000000178230759 66 0f 57 c0                    xorpd xmm0, xmm0
000000017823075d f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230762 f3 44 0f 11 bc 24 90 00 00 00  movss [rsp+0x90], xmm15
000000017823076c 89 84 24 90 00 00 00           mov [rsp+0x90], eax
0000000178230773 89 84 24 88 00 00 00           mov [rsp+0x88], eax
000000017823077a f3 0f 10 84 24 88 00 00 00     movss xmm0, dword [rsp+0x88]
0000000178230783 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
0000000178230787 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
000000017823078c f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
0000000178230796 f3 0f 10 84 24 a8 00 00 00     movss xmm0, dword [rsp+0xa8]
000000017823079f f3 0f 5a c0                    cvtss2sd xmm0, xmm0
00000001782307a3 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
00000001782307a8 f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
00000001782307b2 f3 0f 10 9c 24 a8 00 00 00     movss xmm3, dword [rsp+0xa8]
00000001782307bb f3 0f 5a db                    cvtss2sd xmm3, xmm3
00000001782307bf 48 63 84 24 b8 00 00 00        movsxd rax, dword [rsp+0xb8]
00000001782307c7 89 44 24 78                    mov [rsp+0x78], eax
00000001782307cb 48 63 84 24 bc 00 00 00        movsxd rax, dword [rsp+0xbc]
00000001782307d3 89 44 24 7c                    mov [rsp+0x7c], eax
00000001782307d7 48 63 84 24 c0 00 00 00        movsxd rax, dword [rsp+0xc0]
00000001782307df 89 84 24 80 00 00 00           mov [rsp+0x80], eax
00000001782307e6 48 63 84 24 c4 00 00 00        movsxd rax, dword [rsp+0xc4]
00000001782307ee 89 84 24 84 00 00 00           mov [rsp+0x84], eax
00000001782307f5 8b 44 24 7c                    mov eax, [rsp+0x7c]
00000001782307f9 c7 44 24 70 00 00 00 00        mov dword [rsp+0x70], 0x0
0000000178230801 66 0f 57 c0                    xorpd xmm0, xmm0
0000000178230805 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
000000017823080a f3 44 0f 11 7c 24 70           movss [rsp+0x70], xmm15
0000000178230811 89 44 24 70                    mov [rsp+0x70], eax
0000000178230815 89 44 24 68                    mov [rsp+0x68], eax
0000000178230819 f3 0f 10 44 24 68              movss xmm0, dword [rsp+0x68]
000000017823081f f3 0f 5a c0                    cvtss2sd xmm0, xmm0
0000000178230823 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230828 f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
0000000178230832 f3 0f 10 84 24 a8 00 00 00     movss xmm0, dword [rsp+0xa8]
000000017823083b f3 0f 5a c0                    cvtss2sd xmm0, xmm0
000000017823083f f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230844 f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
000000017823084e f3 0f 10 94 24 a8 00 00 00     movss xmm2, dword [rsp+0xa8]
0000000178230857 f3 0f 5a d2                    cvtss2sd xmm2, xmm2
000000017823085b 48 63 84 24 b8 00 00 00        movsxd rax, dword [rsp+0xb8]
0000000178230863 89 44 24 58                    mov [rsp+0x58], eax
0000000178230867 48 63 84 24 bc 00 00 00        movsxd rax, dword [rsp+0xbc]
000000017823086f 89 44 24 5c                    mov [rsp+0x5c], eax
0000000178230873 48 63 84 24 c0 00 00 00        movsxd rax, dword [rsp+0xc0]
000000017823087b 89 44 24 60                    mov [rsp+0x60], eax
000000017823087f 48 63 84 24 c4 00 00 00        movsxd rax, dword [rsp+0xc4]
0000000178230887 89 44 24 64                    mov [rsp+0x64], eax
000000017823088b 8b 44 24 60                    mov eax, [rsp+0x60]
000000017823088f c7 44 24 50 00 00 00 00        mov dword [rsp+0x50], 0x0
0000000178230897 66 0f 57 c0                    xorpd xmm0, xmm0
000000017823089b f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
00000001782308a0 f3 44 0f 11 7c 24 50           movss [rsp+0x50], xmm15
00000001782308a7 89 44 24 50                    mov [rsp+0x50], eax
00000001782308ab 89 44 24 48                    mov [rsp+0x48], eax
00000001782308af f3 0f 10 44 24 48              movss xmm0, dword [rsp+0x48]
00000001782308b5 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
00000001782308b9 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
00000001782308be f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
00000001782308c8 f3 0f 10 84 24 a8 00 00 00     movss xmm0, dword [rsp+0xa8]
00000001782308d1 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
00000001782308d5 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
00000001782308da f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
00000001782308e4 f3 0f 10 8c 24 a8 00 00 00     movss xmm1, dword [rsp+0xa8]
00000001782308ed f3 0f 5a c9                    cvtss2sd xmm1, xmm1
00000001782308f1 48 63 84 24 b8 00 00 00        movsxd rax, dword [rsp+0xb8]
00000001782308f9 89 44 24 38                    mov [rsp+0x38], eax
00000001782308fd 48 63 84 24 bc 00 00 00        movsxd rax, dword [rsp+0xbc]
0000000178230905 89 44 24 3c                    mov [rsp+0x3c], eax
0000000178230909 48 63 84 24 c0 00 00 00        movsxd rax, dword [rsp+0xc0]
0000000178230911 89 44 24 40                    mov [rsp+0x40], eax
0000000178230915 48 63 84 24 c4 00 00 00        movsxd rax, dword [rsp+0xc4]
000000017823091d 89 44 24 44                    mov [rsp+0x44], eax
0000000178230921 8b 44 24 44                    mov eax, [rsp+0x44]
0000000178230925 c7 44 24 30 00 00 00 00        mov dword [rsp+0x30], 0x0
000000017823092d 66 0f 57 c0                    xorpd xmm0, xmm0
0000000178230931 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230936 f3 44 0f 11 7c 24 30           movss [rsp+0x30], xmm15
000000017823093d 89 44 24 30                    mov [rsp+0x30], eax
0000000178230941 89 44 24 28                    mov [rsp+0x28], eax
0000000178230945 f3 0f 10 44 24 28              movss xmm0, dword [rsp+0x28]
000000017823094b f3 0f 5a c0                    cvtss2sd xmm0, xmm0
000000017823094f f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230954 f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
000000017823095e f3 0f 10 84 24 a8 00 00 00     movss xmm0, dword [rsp+0xa8]
0000000178230967 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
000000017823096b f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230970 f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
000000017823097a f3 0f 10 84 24 a8 00 00 00     movss xmm0, dword [rsp+0xa8]
0000000178230983 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
0000000178230987 f2 44 0f 5a fb                 cvtsd2ss xmm15, xmm3
000000017823098c f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
0000000178230996 f2 44 0f 5a fa                 cvtsd2ss xmm15, xmm2
000000017823099b f3 44 0f 11 bc 24 ac 00 00 00  movss [rsp+0xac], xmm15
00000001782309a5 f2 44 0f 5a f9                 cvtsd2ss xmm15, xmm1
00000001782309aa f3 44 0f 11 bc 24 b0 00 00 00  movss [rsp+0xb0], xmm15
00000001782309b4 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
00000001782309b9 f3 44 0f 11 bc 24 b4 00 00 00  movss [rsp+0xb4], xmm15
00000001782309c3 f3 0f 10 9c 24 a8 00 00 00     movss xmm3, dword [rsp+0xa8]
00000001782309cc f3 0f 5a db                    cvtss2sd xmm3, xmm3
00000001782309d0 f3 0f 10 94 24 ac 00 00 00     movss xmm2, dword [rsp+0xac]
00000001782309d9 f3 0f 5a d2                    cvtss2sd xmm2, xmm2
00000001782309dd f3 0f 10 8c 24 b0 00 00 00     movss xmm1, dword [rsp+0xb0]
00000001782309e6 f3 0f 5a c9                    cvtss2sd xmm1, xmm1
00000001782309ea f3 0f 10 84 24 b4 00 00 00     movss xmm0, dword [rsp+0xb4]
00000001782309f3 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
00000001782309f7 c7 44 24 18 00 00 00 00        mov dword [rsp+0x18], 0x0
00000001782309ff c7 44 24 1c 00 00 00 00        mov dword [rsp+0x1c], 0x0
0000000178230a07 c7 44 24 20 00 00 00 00        mov dword [rsp+0x20], 0x0
0000000178230a0f c7 44 24 24 00 00 00 00        mov dword [rsp+0x24], 0x0
0000000178230a17 f2 44 0f 5a fb                 cvtsd2ss xmm15, xmm3
0000000178230a1c f3 44 0f 11 bc 24 b4 00 00 00  movss [rsp+0xb4], xmm15
0000000178230a26 f2 44 0f 5a fa                 cvtsd2ss xmm15, xmm2
0000000178230a2b f3 44 0f 11 bc 24 b0 00 00 00  movss [rsp+0xb0], xmm15
0000000178230a35 f2 44 0f 5a f9                 cvtsd2ss xmm15, xmm1
0000000178230a3a f3 44 0f 11 bc 24 ac 00 00 00  movss [rsp+0xac], xmm15
0000000178230a44 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230a49 f3 44 0f 11 bc 24 a8 00 00 00  movss [rsp+0xa8], xmm15
0000000178230a53 f3 0f 10 84 24 b4 00 00 00     movss xmm0, dword [rsp+0xb4]
0000000178230a5c f3 0f 5a c0                    cvtss2sd xmm0, xmm0
0000000178230a60 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230a65 f3 44 0f 11 7c 24 18           movss [rsp+0x18], xmm15
0000000178230a6c f3 0f 10 84 24 b0 00 00 00     movss xmm0, dword [rsp+0xb0]
0000000178230a75 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
0000000178230a79 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230a7e f3 44 0f 11 7c 24 1c           movss [rsp+0x1c], xmm15
0000000178230a85 f3 0f 10 84 24 ac 00 00 00     movss xmm0, dword [rsp+0xac]
0000000178230a8e f3 0f 5a c0                    cvtss2sd xmm0, xmm0
0000000178230a92 f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230a97 f3 44 0f 11 7c 24 20           movss [rsp+0x20], xmm15
0000000178230a9e f3 0f 10 84 24 a8 00 00 00     movss xmm0, dword [rsp+0xa8]
0000000178230aa7 f3 0f 5a c0                    cvtss2sd xmm0, xmm0
0000000178230aab f2 44 0f 5a f8                 cvtsd2ss xmm15, xmm0
0000000178230ab0 f3 44 0f 11 7c 24 24           movss [rsp+0x24], xmm15
0000000178230ab7 48 63 44 24 18                 movsxd rax, dword [rsp+0x18]
0000000178230abc 89 44 24 08                    mov [rsp+0x8], eax
0000000178230ac0 48 63 44 24 1c                 movsxd rax, dword [rsp+0x1c]
0000000178230ac5 89 44 24 0c                    mov [rsp+0xc], eax
0000000178230ac9 48 63 44 24 20                 movsxd rax, dword [rsp+0x20]
0000000178230ace 89 44 24 10                    mov [rsp+0x10], eax
0000000178230ad2 48 63 44 24 24                 movsxd rax, dword [rsp+0x24]
0000000178230ad7 89 44 24 14                    mov [rsp+0x14], eax
0000000178230adb 48 8b 04 24                    mov rax, [rsp]               ; read singlestep trampoline
0000000178230adf 48 63 4c 24 08                 movsxd rcx, dword [rsp+0x8]
0000000178230ae4 89 08                          mov [rax], ecx
0000000178230ae6 48 63 4c 24 0c                 movsxd rcx, dword [rsp+0xc]
0000000178230aeb 89 48 04                       mov [rax+0x4], ecx
0000000178230aee 48 63 4c 24 10                 movsxd rcx, dword [rsp+0x10]
0000000178230af3 89 48 08                       mov [rax+0x8], ecx
0000000178230af6 48 63 4c 24 14                 movsxd rcx, dword [rsp+0x14]
0000000178230afb 89 48 0c                       mov [rax+0xc], ecx
0000000178230afe 48 81 c4 c8 00 00 00           add rsp, 0xc8                ; 200
0000000178230b05 c3                             ret
```

With this change, mono generates much better code:

```
public static Unity.Mathematics.float4 asfloat(Unity.Mathematics.uint4 x)
Address: 0000000177F76640
Code Size in Bytes: 94
Debug mode: enabled

0000000177f76640 48 83 ec 28                    sub rsp, 0x28
0000000177f76644 48 89 3c 24                    mov [rsp], rdi
0000000177f76648 48 89 74 24 18                 mov [rsp+0x18], rsi
0000000177f7664d 48 89 54 24 20                 mov [rsp+0x20], rdx
0000000177f76652 48 8d 44 24 18                 lea rax, [rsp+0x18]
0000000177f76657 48 63 08                       movsxd rcx, dword [rax]
0000000177f7665a 89 4c 24 08                    mov [rsp+0x8], ecx
0000000177f7665e 48 63 48 04                    movsxd rcx, dword [rax+0x4]
0000000177f76662 89 4c 24 0c                    mov [rsp+0xc], ecx
0000000177f76666 48 63 48 08                    movsxd rcx, dword [rax+0x8]
0000000177f7666a 89 4c 24 10                    mov [rsp+0x10], ecx
0000000177f7666e 48 63 40 0c                    movsxd rax, dword [rax+0xc]
0000000177f76672 89 44 24 14                    mov [rsp+0x14], eax
0000000177f76676 48 8b 04 24                    mov rax, [rsp]               ; read singlestep trampoline
0000000177f7667a 48 63 4c 24 08                 movsxd rcx, dword [rsp+0x8]
0000000177f7667f 89 08                          mov [rax], ecx
0000000177f76681 48 63 4c 24 0c                 movsxd rcx, dword [rsp+0xc]
0000000177f76686 89 48 04                       mov [rax+0x4], ecx
0000000177f76689 48 63 4c 24 10                 movsxd rcx, dword [rsp+0x10]
0000000177f7668e 89 48 08                       mov [rax+0x8], ecx
0000000177f76691 48 63 4c 24 14                 movsxd rcx, dword [rsp+0x14]
0000000177f76696 89 48 0c                       mov [rax+0xc], ecx
0000000177f76699 48 83 c4 28                    add rsp, 0x28                ; 40
0000000177f7669d c3                             ret
```

Some select perf numbers with my MacBook Pro that has an Intel(R) Core(TM) i9-9880H CPU (times are in microseconds and the burst times tend to be noisier due to its fast perf):

| Method name          | Baseline time | New time | Speedup     | Bursted method       | Baseline time | New time | Speedup      | Baseline mono to burst speedup | New mono to burst speedup |
| -------------------- | ------------- | -------- | ----------- | -------------------- | ------------- | -------- | ------------ | ------------------------------ | ------------------------- |
| quaternion(float3x3) | 61798         | 32110.8  | 1.924523836 | quaternion(float3x3) | 769.3         | 719.6    | 1.069066148  | 80.33017028                    | 44.62312396               |
| float3x3(quaternion) | 58635.2       | 28391.3  | 2.065252384 | float3x3(quaternion) | 431.3         | 423.3    | 1.018899126  | 135.9499188                    | 67.0713442                |
| asdouble(long)       | 7618.4        | 4769.9   | 1.597182331 | asdouble(long)       | 2382          | 2330.4   | 1.022142122  | 3.198320739                    | 2.046815997               |
| asdouble(ulong)      | 8511.9        | 5011.7   | 1.698405731 | asdouble(ulong)      | 2698.1        | 2786.3   | 0.9683451172 | 3.154775583                    | 1.798693608               |
| asfloat(int)         | 19374.9       | 18299.4  | 1.058772419 | asfloat(int)         | 2401.9        | 2392     | 1.004138796  | 8.06648903                     | 7.650250836               |
| asfloat(int2)        | 51035.4       | 9435.6   | 5.40881343  | asfloat(int2)        | 3237.4        | 2718.8   | 1.190745917  | 15.76431704                    | 3.470501692               |
| asfloat(int3)        | 64999.7       | 13369.1  | 4.861935358 | asfloat(int3)        | 4275.2        | 4036.9   | 1.059030444  | 15.20389689                    | 3.311724343               |
| asfloat(int4)        | 89697.4       | 16437.9  | 5.456743258 | asfloat(int4)        | 4424.5        | 4429.2   | 0.9989388603 | 20.27288959                    | 3.711257112               |
| asfloat(uint)        | 34714.1       | 18243.4  | 1.902830613 | asfloat(uint)        | 2379          | 2447     | 0.9722108705 | 14.59188735                    | 7.455414794               |
| asfloat(uint2)       | 77753.7       | 9116.3   | 8.529085265 | asfloat(uint2)       | 3338.8        | 3365.5   | 0.9920665577 | 23.28791781                    | 2.708750557               |
| asfloat(uint3)       | 94821         | 11836.8  | 8.010695458 | asfloat(uint3)       | 4442.3        | 5008.8   | 0.8868990577 | 21.34502397                    | 2.363200767               |
| asfloat(uint4)       | 126617.6      | 14791.6  | 8.560101679 | asfloat(uint4)       | 3438.9        | 3796.2   | 0.9058795638 | 36.81921545                    | 3.896422739               |
| asint(float)         | 18490.1       | 5898.4   | 3.13476536  | asint(float)         | 2419.3        | 2374.7   | 1.01878132   | 7.642747902                    | 2.483850592               |
| asint(float2)        | 34440.1       | 8332.7   | 4.133126118 | asint(float2)        | 2790.6        | 2839.5   | 0.9827786582 | 12.34146778                    | 2.934565945               |
| asint(float3)        | 50039         | 12297.4  | 4.069071511 | asint(float3)        | 4216          | 4045.8   | 1.042068318  | 11.86883302                    | 3.039547185               |
| asint(float4)        | 70182.5       | 15752.9  | 4.455211421 | asint(float4)        | 4576.6        | 3754.5   | 1.21896391   | 15.33507407                    | 4.195738447               |
| aslong(double)       | 7773.6        | 4980.1   | 1.560932511 | aslong(double)       | 2645.7        | 2800     | 0.9448928571 | 2.93820161                     | 1.778607143               |
| asuint(float)        | 32331.1       | 8161.3   | 3.961513484 | asuint(float)        | 2393.5        | 2373.7   | 1.008341408  | 13.5078755                     | 3.438218815               |
| asuint(float2)       | 61567.8       | 7720.1   | 7.975000324 | asuint(float2)       | 2781.9        | 2836     | 0.9809238364 | 22.13156476                    | 2.722179126               |
| asuint(float3)       | 91175.7       | 11956.7  | 7.625490311 | asuint(float3)       | 4323.1        | 4622.7   | 0.9351893915 | 21.09035183                    | 2.586518701               |
| asuint(float4)       | 123315        | 15099.6  | 8.16677263  | asuint(float4)       | 4155.6        | 3510.1   | 1.183897895  | 29.67441525                    | 4.301757785               |
| asulong(double)      | 8134.1        | 4848.5   | 1.677652882 | asulong(double)      | 2644.4        | 2614.2   | 1.011552291  | 3.075971865                    | 1.854678295               |