### PR TITLE
Make Il2CppEagerStaticClassConstructionAttribute internal.

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -17,6 +17,7 @@
 * `asfloat(uint)`, `asuint(float)`, `asint(float)` and other related methods are now faster in mono without Burst. Other methods which use these will see a performance improvement.
 * Modified `quaternion.nlerp` to be branchless.
 * More descriptive parameter names for many methods in `math` class.
+* Made `Il2CppEagerStaticClassConstructionAttribute` internal to avoid conflicts with other definitions outside of the package.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Unity.Mathematics/Il2CppEagerStaticClassConstructionAttribute.cs
+++ b/src/Unity.Mathematics/Il2CppEagerStaticClassConstructionAttribute.cs
@@ -7,7 +7,7 @@ namespace Unity.IL2CPP.CompilerServices
     /// rather than lazily at runtime.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
-    public class Il2CppEagerStaticClassConstructionAttribute : Attribute
+    internal class Il2CppEagerStaticClassConstructionAttribute : Attribute
     {
     }
 }


### PR DESCRIPTION
Having this attribute public made it possible to conflict with
definitions made elsewhere. Hiding it as internal will avoid the
possibility of our definition conflicting with another.