### PR TITLE
More descriptive parameter names

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 * `asfloat(uint)`, `asuint(float)`, `asint(float)` and other related methods are now faster in mono without Burst. Other methods which use these will see a performance improvement.
 * Modified `quaternion.nlerp` to be branchless.
+* More descriptive parameter names for many methods in `math` class.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -1057,162 +1057,162 @@ namespace Unity.Mathematics
         public static double4 max(double4 x, double4 y) { return new double4(max(x.x, y.x), max(x.y, y.y), max(x.z, y.z), max(x.w, y.w)); }
 
 
-        /// <summary>Returns the result of linearly interpolating from x to y using the interpolation parameter s.</summary>
+        /// <summary>Returns the result of linearly interpolating from start to end using the interpolation parameter t.</summary>
         /// <remarks>
         /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
         /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <returns>The interpolation from start to end.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float lerp(float start, float end, float t) { return start + t * (end - start); }
+
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter t.</summary>
+        /// <remarks>
+        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
+        /// </remarks>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <returns>The componentwise interpolation from x to y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float2 lerp(float2 start, float2 end, float t) { return start + t * (end - start); }
+
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter t.</summary>
+        /// <remarks>
+        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
+        /// </remarks>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <returns>The componentwise interpolation from x to y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 lerp(float3 start, float3 end, float t) { return start + t * (end - start); }
+
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter t.</summary>
+        /// <remarks>
+        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
+        /// </remarks>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <returns>The componentwise interpolation from x to y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float4 lerp(float4 start, float4 end, float t) { return start + t * (end - start); }
+
+
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter t.</summary>
+        /// <remarks>
+        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
+        /// </remarks>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <returns>The componentwise interpolation from x to y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float2 lerp(float2 start, float2 end, float2 t) { return start + t * (end - start); }
+
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter t.</summary>
+        /// <remarks>
+        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
+        /// </remarks>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <returns>The componentwise interpolation from x to y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 lerp(float3 start, float3 end, float3 t) { return start + t * (end - start); }
+
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter t.</summary>
+        /// <remarks>
+        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
+        /// </remarks>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <returns>The componentwise interpolation from x to y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float4 lerp(float4 start, float4 end, float4 t) { return start + t * (end - start); }
+
+
+        /// <summary>Returns the result of linearly interpolating from x to y using the interpolation parameter t.</summary>
+        /// <remarks>
+        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
+        /// </remarks>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
         /// <returns>The interpolation from x to y.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float lerp(float x, float y, float s) { return x + s * (y - x); }
+        public static double lerp(double start, double end, double t) { return start + t * (end - start); }
 
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter s.</summary>
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter t.</summary>
         /// <remarks>
         /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
         /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
         /// <returns>The componentwise interpolation from x to y.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 lerp(float2 x, float2 y, float s) { return x + s * (y - x); }
+        public static double2 lerp(double2 start, double2 end, double t) { return start + t * (end - start); }
 
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter s.</summary>
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter t.</summary>
         /// <remarks>
         /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
         /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
         /// <returns>The componentwise interpolation from x to y.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 lerp(float3 x, float3 y, float s) { return x + s * (y - x); }
+        public static double3 lerp(double3 start, double3 end, double t) { return start + t * (end - start); }
 
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter s.</summary>
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter t.</summary>
         /// <remarks>
         /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
         /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
         /// <returns>The componentwise interpolation from x to y.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 lerp(float4 x, float4 y, float s) { return x + s * (y - x); }
+        public static double4 lerp(double4 start, double4 end, double t) { return start + t * (end - start); }
 
 
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter s.</summary>
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter t.</summary>
         /// <remarks>
         /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
         /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
         /// <returns>The componentwise interpolation from x to y.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 lerp(float2 x, float2 y, float2 s) { return x + s * (y - x); }
+        public static double2 lerp(double2 start, double2 end, double2 t) { return start + t * (end - start); }
 
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter s.</summary>
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter t.</summary>
         /// <remarks>
         /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
         /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
         /// <returns>The componentwise interpolation from x to y.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 lerp(float3 x, float3 y, float3 s) { return x + s * (y - x); }
+        public static double3 lerp(double3 start, double3 end, double3 t) { return start + t * (end - start); }
 
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter s.</summary>
+        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter t.</summary>
         /// <remarks>
         /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
         /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
+        /// <param name="start">The start point, corresponding to the interpolation parameter value of 0.</param>
+        /// <param name="end">The end point, corresponding to the interpolation parameter value of 1.</param>
+        /// <param name="t">The interpolation parameter. May be a value outside the interval [0, 1].</param>
         /// <returns>The componentwise interpolation from x to y.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 lerp(float4 x, float4 y, float4 s) { return x + s * (y - x); }
-
-
-        /// <summary>Returns the result of linearly interpolating from x to y using the interpolation parameter s.</summary>
-        /// <remarks>
-        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
-        /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
-        /// <returns>The interpolation from x to y.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double lerp(double x, double y, double s) { return x + s * (y - x); }
-
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter s.</summary>
-        /// <remarks>
-        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
-        /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
-        /// <returns>The componentwise interpolation from x to y.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 lerp(double2 x, double2 y, double s) { return x + s * (y - x); }
-
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter s.</summary>
-        /// <remarks>
-        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
-        /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
-        /// <returns>The componentwise interpolation from x to y.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 lerp(double3 x, double3 y, double s) { return x + s * (y - x); }
-
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the interpolation parameter s.</summary>
-        /// <remarks>
-        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
-        /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
-        /// <returns>The componentwise interpolation from x to y.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 lerp(double4 x, double4 y, double s) { return x + s * (y - x); }
-
-
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter s.</summary>
-        /// <remarks>
-        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
-        /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
-        /// <returns>The componentwise interpolation from x to y.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 lerp(double2 x, double2 y, double2 s) { return x + s * (y - x); }
-
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter s.</summary>
-        /// <remarks>
-        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
-        /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
-        /// <returns>The componentwise interpolation from x to y.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 lerp(double3 x, double3 y, double3 s) { return x + s * (y - x); }
-
-        /// <summary>Returns the result of a componentwise linear interpolating from x to y using the corresponding components of the interpolation parameter s.</summary>
-        /// <remarks>
-        /// If the interpolation parameter is not in the range [0, 1], then this function extrapolates.
-        /// </remarks>
-        /// <param name="x">The first endpoint, corresponding to the interpolation parameter value of 0.</param>
-        /// <param name="y">The second endpoint, corresponding to the interpolation parameter value of 1.</param>
-        /// <param name="s">The interpolation parameter. May be a value outside the interval [0, 1].</param>
-        /// <returns>The componentwise interpolation from x to y.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 lerp(double4 x, double4 y, double4 s) { return x + s * (y - x); }
+        public static double4 lerp(double4 start, double4 end, double4 t) { return start + t * (end - start); }
 
 
         /// <summary>Returns the result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -1553,153 +1553,153 @@ namespace Unity.Mathematics
         public static double4 mad(double4 mulA, double4 mulB, double4 addC) { return mulA * mulB + addC; }
 
 
-        /// <summary>Returns the result of clamping the value x into the interval [a, b], where x, a and b are int values.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of clamping the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are int values.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int clamp(int x, int a, int b) { return max(a, min(b, x)); }
+        public static int clamp(int valueToClamp, int lowerBound, int upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
         /// <summary>Returns the result of a componentwise clamping of the int2 x into the interval [a, b], where a and b are int2 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int2 clamp(int2 x, int2 a, int2 b) { return max(a, min(b, x)); }
+        public static int2 clamp(int2 valueToClamp, int2 lowerBound, int2 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
         /// <summary>Returns the result of a componentwise clamping of the int3 x into the interval [a, b], where x, a and b are int3 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int3 clamp(int3 x, int3 a, int3 b) { return max(a, min(b, x)); }
+        public static int3 clamp(int3 valueToClamp, int3 lowerBound, int3 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are int4 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are int4 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int4 clamp(int4 x, int4 a, int4 b) { return max(a, min(b, x)); }
+        public static int4 clamp(int4 valueToClamp, int4 lowerBound, int4 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
 
-        /// <summary>Returns the result of clamping the value x into the interval [a, b], where x, a and b are uint values.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of clamping the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are uint values.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint clamp(uint x, uint a, uint b) { return max(a, min(b, x)); }
+        public static uint clamp(uint valueToClamp, uint lowerBound, uint upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are uint2 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are uint2 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint2 clamp(uint2 x, uint2 a, uint2 b) { return max(a, min(b, x)); }
+        public static uint2 clamp(uint2 valueToClamp, uint2 lowerBound, uint2 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are uint3 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are uint3 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint3 clamp(uint3 x, uint3 a, uint3 b) { return max(a, min(b, x)); }
+        public static uint3 clamp(uint3 valueToClamp, uint3 lowerBound, uint3 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are uint4 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are uint4 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint4 clamp(uint4 x, uint4 a, uint4 b) { return max(a, min(b, x)); }
+        public static uint4 clamp(uint4 valueToClamp, uint4 lowerBound, uint4 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
 
-        /// <summary>Returns the result of clamping the value x into the interval [a, b], where x, a and b are long values.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of clamping the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are long values.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long clamp(long x, long a, long b) { return max(a, min(b, x)); }
+        public static long clamp(long valueToClamp, long lowerBound, long upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of clamping the value x into the interval [a, b], where x, a and b are ulong values.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of clamping the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are ulong values.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong clamp(ulong x, ulong a, ulong b) { return max(a, min(b, x)); }
+        public static ulong clamp(ulong valueToClamp, ulong lowerBound, ulong upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
 
-        /// <summary>Returns the result of clamping the value x into the interval [a, b], where x, a and b are float values.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of clamping the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are float values.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float clamp(float x, float a, float b) { return max(a, min(b, x)); }
+        public static float clamp(float valueToClamp, float lowerBound, float upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are float2 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are float2 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 clamp(float2 x, float2 a, float2 b) { return max(a, min(b, x)); }
+        public static float2 clamp(float2 valueToClamp, float2 lowerBound, float2 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are float3 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are float3 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 clamp(float3 x, float3 a, float3 b) { return max(a, min(b, x)); }
+        public static float3 clamp(float3 valueToClamp, float3 lowerBound, float3 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are float4 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are float4 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 clamp(float4 x, float4 a, float4 b) { return max(a, min(b, x)); }
+        public static float4 clamp(float4 valueToClamp, float4 lowerBound, float4 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
 
-        /// <summary>Returns the result of clamping the value x into the interval [a, b], where x, a and b are double values.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of clamping the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are double values.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double clamp(double x, double a, double b) { return max(a, min(b, x)); }
+        public static double clamp(double valueToClamp, double lowerBound, double upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are double2 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are double2 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 clamp(double2 x, double2 a, double2 b) { return max(a, min(b, x)); }
+        public static double2 clamp(double2 valueToClamp, double2 lowerBound, double2 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are double3 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are double3 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 clamp(double3 x, double3 a, double3 b) { return max(a, min(b, x)); }
+        public static double3 clamp(double3 valueToClamp, double3 lowerBound, double3 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
-        /// <summary>Returns the result of a componentwise clamping of the value x into the interval [a, b], where x, a and b are double4 vectors.</summary>
-        /// <param name="x">Input value to be clamped.</param>
-        /// <param name="a">Lower bound of the interval.</param>
-        /// <param name="b">Upper bound of the interval.</param>
-        /// <returns>The componentwise clamping of the input x into the interval [a, b].</returns>
+        /// <summary>Returns the result of a componentwise clamping of the value valueToClamp into the interval (inclusive) [lowerBound, upperBound], where valueToClamp, lowerBound and upperBound are double4 vectors.</summary>
+        /// <param name="valueToClamp">Input value to be clamped.</param>
+        /// <param name="lowerBound">Lower bound of the interval.</param>
+        /// <param name="upperBound">Upper bound of the interval.</param>
+        /// <returns>The componentwise clamping of the input valueToClamp into the interval (inclusive) [lowerBound, upperBound].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 clamp(double4 x, double4 a, double4 b) { return max(a, min(b, x)); }
+        public static double4 clamp(double4 valueToClamp, double4 lowerBound, double4 upperBound) { return max(lowerBound, min(upperBound, valueToClamp)); }
 
 
         /// <summary>Returns the result of clamping the float value x into the interval [0, 1].</summary>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -4450,83 +4450,83 @@ namespace Unity.Mathematics
         public static double4 reflect(double4 i, double4 n) { return i - 2 * n * dot(i, n); }
 
 
-        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index eta.</summary>
+        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index.</summary>
         /// <param name="i">Incident vector.</param>
         /// <param name="n">Normal vector.</param>
-        /// <param name="eta">Index of refraction.</param>
+        /// <param name="indexOfRefraction">Index of refraction.</param>
         /// <returns>Refraction vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 refract(float2 i, float2 n, float eta)
+        public static float2 refract(float2 i, float2 n, float indexOfRefraction)
         {
             float ni = dot(n, i);
-            float k = 1.0f - eta * eta * (1.0f - ni * ni);
-            return select(0.0f, eta * i - (eta * ni + sqrt(k)) * n, k >= 0);
+            float k = 1.0f - indexOfRefraction * indexOfRefraction * (1.0f - ni * ni);
+            return select(0.0f, indexOfRefraction * i - (indexOfRefraction * ni + sqrt(k)) * n, k >= 0);
         }
 
-        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index eta.</summary>
+        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index.</summary>
         /// <param name="i">Incident vector.</param>
         /// <param name="n">Normal vector.</param>
-        /// <param name="eta">Index of refraction.</param>
+        /// <param name="indexOfRefraction">Index of refraction.</param>
         /// <returns>Refraction vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 refract(float3 i, float3 n, float eta)
+        public static float3 refract(float3 i, float3 n, float indexOfRefraction)
         {
             float ni = dot(n, i);
-            float k = 1.0f - eta * eta * (1.0f - ni * ni);
-            return select(0.0f, eta * i - (eta * ni + sqrt(k)) * n, k >= 0);
+            float k = 1.0f - indexOfRefraction * indexOfRefraction * (1.0f - ni * ni);
+            return select(0.0f, indexOfRefraction * i - (indexOfRefraction * ni + sqrt(k)) * n, k >= 0);
         }
 
-        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index eta.</summary>
+        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index.</summary>
         /// <param name="i">Incident vector.</param>
         /// <param name="n">Normal vector.</param>
-        /// <param name="eta">Index of refraction.</param>
+        /// <param name="indexOfRefraction">Index of refraction.</param>
         /// <returns>Refraction vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 refract(float4 i, float4 n, float eta)
+        public static float4 refract(float4 i, float4 n, float indexOfRefraction)
         {
             float ni = dot(n, i);
-            float k = 1.0f - eta * eta * (1.0f - ni * ni);
-            return select(0.0f, eta * i - (eta * ni + sqrt(k)) * n, k >= 0);
+            float k = 1.0f - indexOfRefraction * indexOfRefraction * (1.0f - ni * ni);
+            return select(0.0f, indexOfRefraction * i - (indexOfRefraction * ni + sqrt(k)) * n, k >= 0);
         }
 
 
-        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index eta.</summary>
+        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index.</summary>
         /// <param name="i">Incident vector.</param>
         /// <param name="n">Normal vector.</param>
-        /// <param name="eta">Index of refraction.</param>
+        /// <param name="indexOfRefraction">Index of refraction.</param>
         /// <returns>Refraction vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 refract(double2 i, double2 n, double eta)
+        public static double2 refract(double2 i, double2 n, double indexOfRefraction)
         {
             double ni = dot(n, i);
-            double k = 1.0 - eta * eta * (1.0 - ni * ni);
-            return select(0.0f, eta * i - (eta * ni + sqrt(k)) * n, k >= 0);
+            double k = 1.0 - indexOfRefraction * indexOfRefraction * (1.0 - ni * ni);
+            return select(0.0f, indexOfRefraction * i - (indexOfRefraction * ni + sqrt(k)) * n, k >= 0);
         }
 
-        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index eta.</summary>
+        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index.</summary>
         /// <param name="i">Incident vector.</param>
         /// <param name="n">Normal vector.</param>
-        /// <param name="eta">Index of refraction.</param>
+        /// <param name="indexOfRefraction">Index of refraction.</param>
         /// <returns>Refraction vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 refract(double3 i, double3 n, double eta)
+        public static double3 refract(double3 i, double3 n, double indexOfRefraction)
         {
             double ni = dot(n, i);
-            double k = 1.0 - eta * eta * (1.0 - ni * ni);
-            return select(0.0f, eta * i - (eta * ni + sqrt(k)) * n, k >= 0);
+            double k = 1.0 - indexOfRefraction * indexOfRefraction * (1.0 - ni * ni);
+            return select(0.0f, indexOfRefraction * i - (indexOfRefraction * ni + sqrt(k)) * n, k >= 0);
         }
 
-        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index eta.</summary>
+        /// <summary>Returns the refraction vector given the incident vector i, the normal vector n and the refraction index.</summary>
         /// <param name="i">Incident vector.</param>
         /// <param name="n">Normal vector.</param>
-        /// <param name="eta">Index of refraction.</param>
+        /// <param name="indexOfRefraction">Index of refraction.</param>
         /// <returns>Refraction vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 refract(double4 i, double4 n, double eta)
+        public static double4 refract(double4 i, double4 n, double indexOfRefraction)
         {
             double ni = dot(n, i);
-            double k = 1.0 - eta * eta * (1.0 - ni * ni);
-            return select(0.0f, eta * i - (eta * ni + sqrt(k)) * n, k >= 0);
+            double k = 1.0 - indexOfRefraction * indexOfRefraction * (1.0 - ni * ni);
+            return select(0.0f, indexOfRefraction * i - (indexOfRefraction * ni + sqrt(k)) * n, k >= 0);
         }
 
         /// <summary>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -3776,100 +3776,100 @@ namespace Unity.Mathematics
         public static double3 cross(double3 x, double3 y) { return (x * y.yzx - x.yzx * y).yzx; }
 
 
-        /// <summary>Returns a smooth Hermite interpolation between 0.0f and 1.0f when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a smooth Hermite interpolation between 0.0f and 1.0f when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns a value camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float smoothstep(float a, float b, float x)
+        public static float smoothstep(float xMin, float xMax, float x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0f - (2.0f * t));
         }
 
-        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0f and 1.0f when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0f and 1.0f when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns component values camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 smoothstep(float2 a, float2 b, float2 x)
+        public static float2 smoothstep(float2 xMin, float2 xMax, float2 x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0f - (2.0f * t));
         }
 
-        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0f and 1.0f when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0f and 1.0f when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns component values camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 smoothstep(float3 a, float3 b, float3 x)
+        public static float3 smoothstep(float3 xMin, float3 xMax, float3 x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0f - (2.0f * t));
         }
 
-        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0f and 1.0f when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0f and 1.0f when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns component values camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 smoothstep(float4 a, float4 b, float4 x)
+        public static float4 smoothstep(float4 xMin, float4 xMax, float4 x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0f - (2.0f * t));
         }
 
 
-        /// <summary>Returns a smooth Hermite interpolation between 0.0 and 1.0 when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a smooth Hermite interpolation between 0.0 and 1.0 when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns a value camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double smoothstep(double a, double b, double x)
+        public static double smoothstep(double xMin, double xMax, double x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0 - (2.0 * t));
         }
 
-        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0 and 1.0 when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0 and 1.0 when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns component values camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 smoothstep(double2 a, double2 b, double2 x)
+        public static double2 smoothstep(double2 xMin, double2 xMax, double2 x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0 - (2.0 * t));
         }
 
-        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0 and 1.0 when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0 and 1.0 when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns component values camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 smoothstep(double3 a, double3 b, double3 x)
+        public static double3 smoothstep(double3 xMin, double3 xMax, double3 x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0 - (2.0 * t));
         }
 
-        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0 and 1.0 when x is in [a, b].</summary>
-        /// <param name="a">The minimum range of the x parameter.</param>
-        /// <param name="b">The maximum range of the x parameter.</param>
+        /// <summary>Returns a componentwise smooth Hermite interpolation between 0.0 and 1.0 when x is in the interval (inclusive) [xMin, xMax].</summary>
+        /// <param name="xMin">The minimum range of the x parameter.</param>
+        /// <param name="xMax">The maximum range of the x parameter.</param>
         /// <param name="x">The value to be interpolated.</param>
         /// <returns>Returns component values camped to the range [0, 1].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 smoothstep(double4 a, double4 b, double4 x)
+        public static double4 smoothstep(double4 xMin, double4 xMax, double4 x)
         {
-            var t = saturate((x - a) / (b - a));
+            var t = saturate((x - xMin) / (xMax - xMin));
             return t * t * (3.0 - (2.0 * t));
         }
 

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -1216,7 +1216,7 @@ namespace Unity.Mathematics
 
 
         /// <summary>Returns the result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="start">The first endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
         /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The interpolation parameter of x with respect to the input range [a, b].</returns>
@@ -1281,170 +1281,170 @@ namespace Unity.Mathematics
         public static double4 unlerp(double4 start, double4 end, double4 x) { return (x - start) / (end - start); }
 
 
-        /// <summary>Returns the result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float remap(float a, float b, float c, float d, float x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static float remap(float srcStart, float srcEnd, float dstStart, float dstEnd, float x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
-        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The componentwise remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 remap(float2 a, float2 b, float2 c, float2 d, float2 x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static float2 remap(float2 srcStart, float2 srcEnd, float2 dstStart, float2 dstEnd, float2 x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
-        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The componentwise remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 remap(float3 a, float3 b, float3 c, float3 d, float3 x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static float3 remap(float3 srcStart, float3 srcEnd, float3 dstStart, float3 dstEnd, float3 x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
-        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The componentwise remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 remap(float4 a, float4 b, float4 c, float4 d, float4 x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static float4 remap(float4 srcStart, float4 srcEnd, float4 dstStart, float4 dstEnd, float4 x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
 
-        /// <summary>Returns the result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double remap(double a, double b, double c, double d, double x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static double remap(double srcStart, double srcEnd, double dstStart, double dstEnd, double x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
-        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The componentwise remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 remap(double2 a, double2 b, double2 c, double2 d, double2 x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static double2 remap(double2 srcStart, double2 srcEnd, double2 dstStart, double2 dstEnd, double2 x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
-        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The componentwise remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 remap(double3 a, double3 b, double3 c, double3 d, double3 x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static double3 remap(double3 srcStart, double3 srcEnd, double3 dstStart, double3 dstEnd, double3 x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
-        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>
-        /// <param name="a">The first endpoint of the source range [a,b].</param>
-        /// <param name="b">The second endpoint of the source range [a, b].</param>
-        /// <param name="c">The first endpoint of the destination range [c, d].</param>
-        /// <param name="d">The second endpoint of the destination range [c, d].</param>
+        /// <summary>Returns the componentwise result of a non-clamping linear remapping of a value x from source range [srcStart, srcEnd] to the destination range [dstStart, dstEnd].</summary>
+        /// <param name="srcStart">The start point of the source range [srcStart, srcEnd].</param>
+        /// <param name="srcEnd">The end point of the source range [srcStart, srcEnd].</param>
+        /// <param name="dstStart">The start point of the destination range [dstStart, dstEnd].</param>
+        /// <param name="dstEnd">The end point of the destination range [dstStart, dstEnd].</param>
         /// <param name="x">The value to remap from the source to destination range.</param>
         /// <returns>The componentwise remap of input x from the source range to the destination range.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 remap(double4 a, double4 b, double4 c, double4 d, double4 x) { return lerp(c, d, unlerp(a, b, x)); }
+        public static double4 remap(double4 srcStart, double4 srcEnd, double4 dstStart, double4 dstEnd, double4 x) { return lerp(dstStart, dstEnd, unlerp(srcStart, srcEnd, x)); }
 
 
         /// <summary>Returns the result of a multiply-add operation (a * b + c) on 3 int values.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int mad(int a, int b, int c) { return a * b + c; }
+        public static int mad(int mulA, int mulB, int addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 int2 vectors.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int2 mad(int2 a, int2 b, int2 c) { return a * b + c; }
+        public static int2 mad(int2 mulA, int2 mulB, int2 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 int3 vectors.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int3 mad(int3 a, int3 b, int3 c) { return a * b + c; }
+        public static int3 mad(int3 mulA, int3 mulB, int3 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 int4 vectors.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int4 mad(int4 a, int4 b, int4 c) { return a * b + c; }
+        public static int4 mad(int4 mulA, int4 mulB, int4 addC) { return mulA * mulB + addC; }
 
 
         /// <summary>Returns the result of a multiply-add operation (a * b + c) on 3 uint values.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint mad(uint a, uint b, uint c) { return a * b + c; }
+        public static uint mad(uint mulA, uint mulB, uint addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 uint2 vectors.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint2 mad(uint2 a, uint2 b, uint2 c) { return a * b + c; }
+        public static uint2 mad(uint2 mulA, uint2 mulB, uint2 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 uint3 vectors.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint3 mad(uint3 a, uint3 b, uint3 c) { return a * b + c; }
+        public static uint3 mad(uint3 mulA, uint3 mulB, uint3 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 uint4 vectors.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint4 mad(uint4 a, uint4 b, uint4 c) { return a * b + c; }
+        public static uint4 mad(uint4 mulA, uint4 mulB, uint4 addC) { return mulA * mulB + addC; }
 
 
         /// <summary>Returns the result of a multiply-add operation (a * b + c) on 3 long values.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long mad(long a, long b, long c) { return a * b + c; }
+        public static long mad(long mulA, long mulB, long addC) { return mulA * mulB + addC; }
 
 
         /// <summary>Returns the result of a multiply-add operation (a * b + c) on 3 ulong values.</summary>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong mad(ulong a, ulong b, ulong c) { return a * b + c; }
+        public static ulong mad(ulong mulA, ulong mulB, ulong addC) { return mulA * mulB + addC; }
 
 
         /// <summary>Returns the result of a multiply-add operation (a * b + c) on 3 float values.</summary>
@@ -1453,12 +1453,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float mad(float a, float b, float c) { return a * b + c; }
+        public static float mad(float mulA, float mulB, float addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 float2 vectors.</summary>
         /// <remarks>
@@ -1466,12 +1466,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 mad(float2 a, float2 b, float2 c) { return a * b + c; }
+        public static float2 mad(float2 mulA, float2 mulB, float2 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 float3 vectors.</summary>
         /// <remarks>
@@ -1479,12 +1479,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 mad(float3 a, float3 b, float3 c) { return a * b + c; }
+        public static float3 mad(float3 mulA, float3 mulB, float3 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 float4 vectors.</summary>
         /// <remarks>
@@ -1492,12 +1492,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 mad(float4 a, float4 b, float4 c) { return a * b + c; }
+        public static float4 mad(float4 mulA, float4 mulB, float4 addC) { return mulA * mulB + addC; }
 
 
         /// <summary>Returns the result of a multiply-add operation (a * b + c) on 3 double values.</summary>
@@ -1506,12 +1506,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double mad(double a, double b, double c) { return a * b + c; }
+        public static double mad(double mulA, double mulB, double addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 double2 vectors.</summary>
         /// <remarks>
@@ -1519,12 +1519,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 mad(double2 a, double2 b, double2 c) { return a * b + c; }
+        public static double2 mad(double2 mulA, double2 mulB, double2 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 double3 vectors.</summary>
         /// <remarks>
@@ -1532,12 +1532,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 mad(double3 a, double3 b, double3 c) { return a * b + c; }
+        public static double3 mad(double3 mulA, double3 mulB, double3 addC) { return mulA * mulB + addC; }
 
         /// <summary>Returns the result of a componentwise multiply-add operation (a * b + c) on 3 double4 vectors.</summary>
         /// <remarks>
@@ -1545,12 +1545,12 @@ namespace Unity.Mathematics
         /// FMA is more accurate due to rounding once at the end of the computation rather than twice that is required when
         /// this computation is not fused.
         /// </remarks>
-        /// <param name="a">First value to multiply.</param>
-        /// <param name="b">Second value to multiply.</param>
-        /// <param name="c">Third value to add to the product of a and b.</param>
+        /// <param name="mulA">First value to multiply.</param>
+        /// <param name="mulB">Second value to multiply.</param>
+        /// <param name="addC">Third value to add to the product of a and b.</param>
         /// <returns>The componentwise multiply-add of the inputs.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 mad(double4 a, double4 b, double4 c) { return a * b + c; }
+        public static double4 mad(double4 mulA, double4 mulB, double4 addC) { return mulA * mulB + addC; }
 
 
         /// <summary>Returns the result of clamping the value x into the interval [a, b], where x, a and b are int values.</summary>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -1216,69 +1216,69 @@ namespace Unity.Mathematics
 
 
         /// <summary>Returns the result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The first endpoint of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float unlerp(float a, float b, float x) { return (x - a) / (b - a); }
+        public static float unlerp(float start, float end, float x) { return (x - start) / (end - start); }
 
         /// <summary>Returns the componentwise result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The componentwise interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 unlerp(float2 a, float2 b, float2 x) { return (x - a) / (b - a); }
+        public static float2 unlerp(float2 start, float2 end, float2 x) { return (x - start) / (end - start); }
 
         /// <summary>Returns the componentwise result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The componentwise interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 unlerp(float3 a, float3 b, float3 x) { return (x - a) / (b - a); }
+        public static float3 unlerp(float3 start, float3 end, float3 x) { return (x - start) / (end - start); }
 
         /// <summary>Returns the componentwise result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The componentwise interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 unlerp(float4 a, float4 b, float4 x) { return (x - a) / (b - a); }
+        public static float4 unlerp(float4 start, float4 end, float4 x) { return (x - start) / (end - start); }
 
 
         /// <summary>Returns the result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double unlerp(double a, double b, double x) { return (x - a) / (b - a); }
+        public static double unlerp(double start, double end, double x) { return (x - start) / (end - start); }
 
         /// <summary>Returns the componentwise result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The componentwise interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 unlerp(double2 a, double2 b, double2 x) { return (x - a) / (b - a); }
+        public static double2 unlerp(double2 start, double2 end, double2 x) { return (x - start) / (end - start); }
 
         /// <summary>Returns the componentwise result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The componentwise interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 unlerp(double3 a, double3 b, double3 x) { return (x - a) / (b - a); }
+        public static double3 unlerp(double3 start, double3 end, double3 x) { return (x - start) / (end - start); }
 
         /// <summary>Returns the componentwise result of normalizing a floating point value x to a range [a, b]. The opposite of lerp. Equivalent to (x - a) / (b - a).</summary>
-        /// <param name="a">The first endpoint of the range.</param>
-        /// <param name="b">The second endpoint of the range.</param>
+        /// <param name="start">The start point of the range.</param>
+        /// <param name="end">The end point of the range.</param>
         /// <param name="x">The value to normalize to the range.</param>
         /// <returns>The componentwise interpolation parameter of x with respect to the input range [a, b].</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 unlerp(double4 a, double4 b, double4 x) { return (x - a) / (b - a); }
+        public static double4 unlerp(double4 start, double4 end, double4 x) { return (x - start) / (end - start); }
 
 
         /// <summary>Returns the result of a non-clamping linear remapping of a value x from source range [a, b] to the destination range [c, d].</summary>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -4348,62 +4348,62 @@ namespace Unity.Mathematics
         public static double4 select(double4 falseValue, double4 trueValue, bool4 test) { return new double4(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z, test.w ? trueValue.w : falseValue.w); }
 
 
-        /// <summary>Returns the result of a step function where the result is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Value to be used as a threshold for returning 1.</param>
-        /// <param name="x">Value to compare against threshold y.</param>
-        /// <returns>1 if the comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a step function where the result is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Value to be used as a threshold for returning 1.</param>
+        /// <param name="x">Value to compare against threshold.</param>
+        /// <returns>1 if the comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float step(float y, float x) { return select(0.0f, 1.0f, x >= y); }
+        public static float step(float threshold, float x) { return select(0.0f, 1.0f, x >= threshold); }
 
-        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Vector of values to be used as a threshold for returning 1.</param>
-        /// <param name="x">Vector of values to compare against threshold y.</param>
-        /// <returns>1 if the componentwise comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Vector of values to be used as a threshold for returning 1.</param>
+        /// <param name="x">Vector of values to compare against threshold.</param>
+        /// <returns>1 if the componentwise comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 step(float2 y, float2 x) { return select(float2(0.0f), float2(1.0f), x >= y); }
+        public static float2 step(float2 threshold, float2 x) { return select(float2(0.0f), float2(1.0f), x >= threshold); }
 
-        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Vector of values to be used as a threshold for returning 1.</param>
-        /// <param name="x">Vector of values to compare against threshold y.</param>
-        /// <returns>1 if the componentwise comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Vector of values to be used as a threshold for returning 1.</param>
+        /// <param name="x">Vector of values to compare against threshold.</param>
+        /// <returns>1 if the componentwise comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 step(float3 y, float3 x) { return select(float3(0.0f), float3(1.0f), x >= y); }
+        public static float3 step(float3 threshold, float3 x) { return select(float3(0.0f), float3(1.0f), x >= threshold); }
 
-        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Vector of values to be used as a threshold for returning 1.</param>
-        /// <param name="x">Vector of values to compare against threshold y.</param>
-        /// <returns>1 if the componentwise comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Vector of values to be used as a threshold for returning 1.</param>
+        /// <param name="x">Vector of values to compare against threshold.</param>
+        /// <returns>1 if the componentwise comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 step(float4 y, float4 x) { return select(float4(0.0f), float4(1.0f), x >= y); }
+        public static float4 step(float4 threshold, float4 x) { return select(float4(0.0f), float4(1.0f), x >= threshold); }
 
 
-        /// <summary>Returns the result of a step function where the result is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Values to be used as a threshold for returning 1.</param>
-        /// <param name="x">Values to compare against threshold y.</param>
-        /// <returns>1 if the comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a step function where the result is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Values to be used as a threshold for returning 1.</param>
+        /// <param name="x">Value to compare against threshold.</param>
+        /// <returns>1 if the comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double step(double y, double x) { return select(0.0, 1.0, x >= y); }
+        public static double step(double threshold, double x) { return select(0.0, 1.0, x >= threshold); }
 
-        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Vector of values to be used as a threshold for returning 1.</param>
-        /// <param name="x">Vector of values to compare against threshold y.</param>
-        /// <returns>1 if the componentwise comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Vector of values to be used as a threshold for returning 1.</param>
+        /// <param name="x">Vector of values to compare against threshold.</param>
+        /// <returns>1 if the componentwise comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 step(double2 y, double2 x) { return select(double2(0.0), double2(1.0), x >= y); }
+        public static double2 step(double2 threshold, double2 x) { return select(double2(0.0), double2(1.0), x >= threshold); }
 
-        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Vector of values to be used as a threshold for returning 1.</param>
-        /// <param name="x">Vector of values to compare against threshold y.</param>
-        /// <returns>1 if the componentwise comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Vector of values to be used as a threshold for returning 1.</param>
+        /// <param name="x">Vector of values to compare against threshold.</param>
+        /// <returns>1 if the componentwise comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 step(double3 y, double3 x) { return select(double3(0.0), double3(1.0), x >= y); }
+        public static double3 step(double3 threshold, double3 x) { return select(double3(0.0), double3(1.0), x >= threshold); }
 
-        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= y and 0.0f otherwise.</summary>
-        /// <param name="y">Vector of values to be used as a threshold for returning 1.</param>
-        /// <param name="x">Vector of values to compare against threshold y.</param>
-        /// <returns>1 if the componentwise comparison x &gt;= y is true, otherwise 0.</returns>
+        /// <summary>Returns the result of a componentwise step function where each component is 1.0f when x &gt;= threshold and 0.0f otherwise.</summary>
+        /// <param name="threshold">Vector of values to be used as a threshold for returning 1.</param>
+        /// <param name="x">Vector of values to compare against threshold.</param>
+        /// <returns>1 if the componentwise comparison x &gt;= threshold is true, otherwise 0.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 step(double4 y, double4 x) { return select(double4(0.0), double4(1.0), x >= y); }
+        public static double4 step(double4 threshold, double4 x) { return select(double4(0.0), double4(1.0), x >= threshold); }
 
 
         /// <summary>Given an incident vector i and a normal vector n, returns the reflection vector r = i - 2.0f * dot(i, n) * n.</summary>

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -4539,12 +4539,12 @@ namespace Unity.Mathematics
         /// which will use a given default value if the result is not finite.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <returns>Vector projection of a onto b.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 project(float2 a, float2 b)
+        public static float2 project(float2 a, float2 ontoB)
         {
-            return (dot(a, b) / dot(b, b)) * b;
+            return (dot(a, ontoB) / dot(ontoB, ontoB)) * ontoB;
         }
 
         /// <summary>
@@ -4557,12 +4557,12 @@ namespace Unity.Mathematics
         /// which will use a given default value if the result is not finite.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <returns>Vector projection of a onto b.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 project(float3 a, float3 b)
+        public static float3 project(float3 a, float3 ontoB)
         {
-            return (dot(a, b) / dot(b, b)) * b;
+            return (dot(a, ontoB) / dot(ontoB, ontoB)) * ontoB;
         }
 
         /// <summary>
@@ -4575,12 +4575,12 @@ namespace Unity.Mathematics
         /// which will use a given default value if the result is not finite.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <returns>Vector projection of a onto b.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 project(float4 a, float4 b)
+        public static float4 project(float4 a, float4 ontoB)
         {
-            return (dot(a, b) / dot(b, b)) * b;
+            return (dot(a, ontoB) / dot(ontoB, ontoB)) * ontoB;
         }
 
         /// <summary>
@@ -4593,13 +4593,13 @@ namespace Unity.Mathematics
         /// function.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <param name="defaultValue">Default value to return if projection is not finite.</param>
         /// <returns>Vector projection of a onto b or the default value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 projectsafe(float2 a, float2 b, float2 defaultValue = new float2())
+        public static float2 projectsafe(float2 a, float2 ontoB, float2 defaultValue = new float2())
         {
-            var proj = project(a, b);
+            var proj = project(a, ontoB);
 
             return select(defaultValue, proj, all(isfinite(proj)));
         }
@@ -4614,13 +4614,13 @@ namespace Unity.Mathematics
         /// function.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <param name="defaultValue">Default value to return if projection is not finite.</param>
         /// <returns>Vector projection of a onto b or the default value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 projectsafe(float3 a, float3 b, float3 defaultValue = new float3())
+        public static float3 projectsafe(float3 a, float3 ontoB, float3 defaultValue = new float3())
         {
-            var proj = project(a, b);
+            var proj = project(a, ontoB);
 
             return select(defaultValue, proj, all(isfinite(proj)));
         }
@@ -4635,13 +4635,13 @@ namespace Unity.Mathematics
         /// function.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <param name="defaultValue">Default value to return if projection is not finite.</param>
         /// <returns>Vector projection of a onto b or the default value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 projectsafe(float4 a, float4 b, float4 defaultValue = new float4())
+        public static float4 projectsafe(float4 a, float4 ontoB, float4 defaultValue = new float4())
         {
-            var proj = project(a, b);
+            var proj = project(a, ontoB);
 
             return select(defaultValue, proj, all(isfinite(proj)));
         }
@@ -4656,12 +4656,12 @@ namespace Unity.Mathematics
         /// which will use a given default value if the result is not finite.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <returns>Vector projection of a onto b.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 project(double2 a, double2 b)
+        public static double2 project(double2 a, double2 ontoB)
         {
-            return (dot(a, b) / dot(b, b)) * b;
+            return (dot(a, ontoB) / dot(ontoB, ontoB)) * ontoB;
         }
 
         /// <summary>
@@ -4674,12 +4674,12 @@ namespace Unity.Mathematics
         /// which will use a given default value if the result is not finite.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <returns>Vector projection of a onto b.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 project(double3 a, double3 b)
+        public static double3 project(double3 a, double3 ontoB)
         {
-            return (dot(a, b) / dot(b, b)) * b;
+            return (dot(a, ontoB) / dot(ontoB, ontoB)) * ontoB;
         }
 
         /// <summary>
@@ -4692,12 +4692,12 @@ namespace Unity.Mathematics
         /// which will use a given default value if the result is not finite.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <returns>Vector projection of a onto b.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 project(double4 a, double4 b)
+        public static double4 project(double4 a, double4 ontoB)
         {
-            return (dot(a, b) / dot(b, b)) * b;
+            return (dot(a, ontoB) / dot(ontoB, ontoB)) * ontoB;
         }
 
         /// <summary>
@@ -4710,13 +4710,13 @@ namespace Unity.Mathematics
         /// function.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <param name="defaultValue">Default value to return if projection is not finite.</param>
         /// <returns>Vector projection of a onto b or the default value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 projectsafe(double2 a, double2 b, double2 defaultValue = new double2())
+        public static double2 projectsafe(double2 a, double2 ontoB, double2 defaultValue = new double2())
         {
-            var proj = project(a, b);
+            var proj = project(a, ontoB);
 
             return select(defaultValue, proj, all(isfinite(proj)));
         }
@@ -4731,13 +4731,13 @@ namespace Unity.Mathematics
         /// function.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <param name="defaultValue">Default value to return if projection is not finite.</param>
         /// <returns>Vector projection of a onto b or the default value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 projectsafe(double3 a, double3 b, double3 defaultValue = new double3())
+        public static double3 projectsafe(double3 a, double3 ontoB, double3 defaultValue = new double3())
         {
-            var proj = project(a, b);
+            var proj = project(a, ontoB);
 
             return select(defaultValue, proj, all(isfinite(proj)));
         }
@@ -4752,13 +4752,13 @@ namespace Unity.Mathematics
         /// function.
         /// </remarks>
         /// <param name="a">Vector to project.</param>
-        /// <param name="b">Non-zero vector to project onto.</param>
+        /// <param name="ontoB">Non-zero vector to project onto.</param>
         /// <param name="defaultValue">Default value to return if projection is not finite.</param>
         /// <returns>Vector projection of a onto b or the default value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 projectsafe(double4 a, double4 b, double4 defaultValue = new double4())
+        public static double4 projectsafe(double4 a, double4 ontoB, double4 defaultValue = new double4())
         {
-            var proj = project(a, b);
+            var proj = project(a, ontoB);
 
             return select(defaultValue, proj, all(isfinite(proj)));
         }

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -4064,288 +4064,288 @@ namespace Unity.Mathematics
         public static bool all(double4 x) { return x.x != 0.0 && x.y != 0.0 && x.z != 0.0 && x.w != 0.0; }
 
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int select(int a, int b, bool c)    { return c ? b : a; }
+        public static int select(int falseValue, int trueValue, bool test)    { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int2 select(int2 a, int2 b, bool c) { return c ? b : a; }
+        public static int2 select(int2 falseValue, int2 trueValue, bool test) { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int3 select(int3 a, int3 b, bool c) { return c ? b : a; }
+        public static int3 select(int3 falseValue, int3 trueValue, bool test) { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int4 select(int4 a, int4 b, bool c) { return c ? b : a; }
+        public static int4 select(int4 falseValue, int4 trueValue, bool test) { return test ? trueValue : falseValue; }
 
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int2 select(int2 a, int2 b, bool2 c) { return new int2(c.x ? b.x : a.x, c.y ? b.y : a.y); }
+        public static int2 select(int2 falseValue, int2 trueValue, bool2 test) { return new int2(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y); }
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int3 select(int3 a, int3 b, bool3 c) { return new int3(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z); }
+        public static int3 select(int3 falseValue, int3 trueValue, bool3 test) { return new int3(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z); }
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int4 select(int4 a, int4 b, bool4 c) { return new int4(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z, c.w ? b.w : a.w); }
+        public static int4 select(int4 falseValue, int4 trueValue, bool4 test) { return new int4(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z, test.w ? trueValue.w : falseValue.w); }
 
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint select(uint a, uint b, bool c) { return c ? b : a; }
+        public static uint select(uint falseValue, uint trueValue, bool test) { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint2 select(uint2 a, uint2 b, bool c) { return c ? b : a; }
+        public static uint2 select(uint2 falseValue, uint2 trueValue, bool test) { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint3 select(uint3 a, uint3 b, bool c) { return c ? b : a; }
+        public static uint3 select(uint3 falseValue, uint3 trueValue, bool test) { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint4 select(uint4 a, uint4 b, bool c) { return c ? b : a; }
-
-
-        /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
-        /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint2 select(uint2 a, uint2 b, bool2 c) { return new uint2(c.x ? b.x : a.x, c.y ? b.y : a.y); }
-
-        /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
-        /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint3 select(uint3 a, uint3 b, bool3 c) { return new uint3(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z); }
-
-        /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
-        /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint4 select(uint4 a, uint4 b, bool4 c) { return new uint4(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z, c.w ? b.w : a.w); }
-
-
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long select(long a, long b, bool c) { return c ? b : a; }
-
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong select(ulong a, ulong b, bool c) { return c ? b : a; }
-
-
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float select(float a, float b, bool c)    { return c ? b : a; }
-
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 select(float2 a, float2 b, bool c) { return c ? b : a; }
-
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 select(float3 a, float3 b, bool c) { return c ? b : a; }
-
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 select(float4 a, float4 b, bool c) { return c ? b : a; }
+        public static uint4 select(uint4 falseValue, uint4 trueValue, bool test) { return test ? trueValue : falseValue; }
 
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float2 select(float2 a, float2 b, bool2 c) { return new float2(c.x ? b.x : a.x, c.y ? b.y : a.y); }
+        public static uint2 select(uint2 falseValue, uint2 trueValue, bool2 test) { return new uint2(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y); }
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 select(float3 a, float3 b, bool3 c) { return new float3(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z); }
+        public static uint3 select(uint3 falseValue, uint3 trueValue, bool3 test) { return new uint3(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z); }
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float4 select(float4 a, float4 b, bool4 c) { return new float4(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z, c.w ? b.w : a.w); }
+        public static uint4 select(uint4 falseValue, uint4 trueValue, bool4 test) { return new uint4(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z, test.w ? trueValue.w : falseValue.w); }
 
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double select(double a, double b, bool c) { return c ? b : a; }
+        public static long select(long falseValue, long trueValue, bool test) { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 select(double2 a, double2 b, bool c) { return c ? b : a; }
+        public static ulong select(ulong falseValue, ulong trueValue, bool test) { return test ? trueValue : falseValue; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 select(double3 a, double3 b, bool c) { return c ? b : a; }
 
-        /// <summary>Returns b if c is true, a otherwise.</summary>
-        /// <param name="a">Value to use if c is false.</param>
-        /// <param name="b">Value to use if c is true.</param>
-        /// <param name="c">Bool value to choose between a and b.</param>
-        /// <returns>The selection between a and b according to bool c.</returns>
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 select(double4 a, double4 b, bool c) { return c ? b : a; }
+        public static float select(float falseValue, float trueValue, bool test)    { return test ? trueValue : falseValue; }
+
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float2 select(float2 falseValue, float2 trueValue, bool test) { return test ? trueValue : falseValue; }
+
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 select(float3 falseValue, float3 trueValue, bool test) { return test ? trueValue : falseValue; }
+
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float4 select(float4 falseValue, float4 trueValue, bool test) { return test ? trueValue : falseValue; }
+
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double2 select(double2 a, double2 b, bool2 c) { return new double2(c.x ? b.x : a.x, c.y ? b.y : a.y); }
+        public static float2 select(float2 falseValue, float2 trueValue, bool2 test) { return new float2(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y); }
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double3 select(double3 a, double3 b, bool3 c) { return new double3(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z); }
+        public static float3 select(float3 falseValue, float3 trueValue, bool3 test) { return new float3(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z); }
 
         /// <summary>
-        /// Returns a componentwise selection between two double4 vectors a and b based on a bool4 selection mask c.
-        /// Per component, the component from b is selected when c is true, otherwise the component from a is selected.
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
         /// </summary>
-        /// <param name="a">Values to use if c is false.</param>
-        /// <param name="b">Values to use if c is true.</param>
-        /// <param name="c">Selection mask to choose between a and b.</param>
-        /// <returns>The componentwise selection between a and b according to selection mask c.</returns>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double4 select(double4 a, double4 b, bool4 c) { return new double4(c.x ? b.x : a.x, c.y ? b.y : a.y, c.z ? b.z : a.z, c.w ? b.w : a.w); }
+        public static float4 select(float4 falseValue, float4 trueValue, bool4 test) { return new float4(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z, test.w ? trueValue.w : falseValue.w); }
+
+
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double select(double falseValue, double trueValue, bool test) { return test ? trueValue : falseValue; }
+
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double2 select(double2 falseValue, double2 trueValue, bool test) { return test ? trueValue : falseValue; }
+
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double3 select(double3 falseValue, double3 trueValue, bool test) { return test ? trueValue : falseValue; }
+
+        /// <summary>Returns trueValue if test is true, falseValue otherwise.</summary>
+        /// <param name="falseValue">Value to use if test is false.</param>
+        /// <param name="trueValue">Value to use if test is true.</param>
+        /// <param name="test">Bool value to choose between falseValue and trueValue.</param>
+        /// <returns>The selection between falseValue and trueValue according to bool test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double4 select(double4 falseValue, double4 trueValue, bool test) { return test ? trueValue : falseValue; }
+
+        /// <summary>
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
+        /// </summary>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double2 select(double2 falseValue, double2 trueValue, bool2 test) { return new double2(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y); }
+
+        /// <summary>
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
+        /// </summary>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double3 select(double3 falseValue, double3 trueValue, bool3 test) { return new double3(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z); }
+
+        /// <summary>
+        /// Returns a componentwise selection between two double4 vectors falseValue and trueValue based on a bool4 selection mask test.
+        /// Per component, the component from trueValue is selected when test is true, otherwise the component from falseValue is selected.
+        /// </summary>
+        /// <param name="falseValue">Values to use if test is false.</param>
+        /// <param name="trueValue">Values to use if test is true.</param>
+        /// <param name="test">Selection mask to choose between falseValue and trueValue.</param>
+        /// <returns>The componentwise selection between falseValue and trueValue according to selection mask test.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double4 select(double4 falseValue, double4 trueValue, bool4 test) { return new double4(test.x ? trueValue.x : falseValue.x, test.y ? trueValue.y : falseValue.y, test.z ? trueValue.z : falseValue.z, test.w ? trueValue.w : falseValue.w); }
 
 
         /// <summary>Returns the result of a step function where the result is 1.0f when x &gt;= y and 0.0f otherwise.</summary>


### PR DESCRIPTION
Many methods had single letter parameter names which were not descriptive and can lead to confusion while writing code. This PR gives many methods in the `math` class more descriptive parameter names.