### PR TITLE
including .csproj.meta files in the git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ Library
 obj
 obj.meta
 # User-specific files
-*.csproj.meta
 *.csproj.user
 *.suo
 *.user

--- a/src/Tests/Unity.Mathematics.Tests.csproj.meta
+++ b/src/Tests/Unity.Mathematics.Tests.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e393530e16da0c6498af8f6417806c74
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Unity.Mathematics.PerformanceTests/Unity.Mathematics.PerformanceTests.csproj.meta
+++ b/src/Unity.Mathematics.PerformanceTests/Unity.Mathematics.PerformanceTests.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83a70727fa33a914d9c1049386e82be7
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Unity.Mathematics/Unity.Mathematics.csproj.meta
+++ b/src/Unity.Mathematics/Unity.Mathematics.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: adc57cbbc95b9e449ba89e2bd869e8d9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/package.json
+++ b/src/package.json
@@ -8,10 +8,5 @@
         "unity"
     ],
     "dependencies": {
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Unity-Technologies/Unity.Mathematics",
-        "revision":""
     }
 }


### PR DESCRIPTION
.csproj.meta files are actually required to be in the git repo, so that the user needn't regenerate them over and over again locally.