### PR TITLE
Mark methods implemented deprecated parent methods as Obsolete to avoid warnings

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## [Unreleased]
 
-### Deprecated
-* `MatrixDrawer.CanCacheInspectorGUI` and `PrimitiveVectorDrawer.CanCacheInspectorGUI` are now marked as `[Obsolete]`. These methods never did anything, and still do not. They will be removed in a future release.
-
 ### Fixed
 * Fixed `math.hash` crash when using IL2CPP builds on Arm 32 bit devices.
+* Fixed obsolete method usage warnings for `MatrixDrawer.CanCacheInspectorGUI` and `PrimitiveVectorDrawer.CanCacheInspectorGUI` in UNITY_2023_2_OR_NEWER.
 
 ## [1.3.1] - 2023-07-12
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## [Unreleased]
-### Added
-### Changed
+
 ### Deprecated
-### Removed
+* `MatrixDrawer.CanCacheInspectorGUI` and `PrimitiveVectorDrawer.CanCacheInspectorGUI` are now marked as `[Obsolete]`. These methods never did anything, and still do not. They will be removed in a future release.
+
 ### Fixed
 * Fixed `math.hash` crash when using IL2CPP builds on Arm 32 bit devices.
 

--- a/src/Unity.Mathematics.Editor/MatrixDrawer.cs
+++ b/src/Unity.Mathematics.Editor/MatrixDrawer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using UnityEditor;
@@ -23,6 +23,7 @@ namespace Unity.Mathematics.Editor
     [CustomPropertyDrawer(typeof(uint4x2)), CustomPropertyDrawer(typeof(uint4x3)), CustomPropertyDrawer(typeof(uint4x4))]
     class MatrixDrawer : PropertyDrawer
     {
+        [Obsolete("CanCacheInspectorGUI has been deprecated, is no longer used and will be removed in later versions.", false)]
         public override bool CanCacheInspectorGUI(SerializedProperty property)
         {
             return false;

--- a/src/Unity.Mathematics.Editor/MatrixDrawer.cs
+++ b/src/Unity.Mathematics.Editor/MatrixDrawer.cs
@@ -23,11 +23,12 @@ namespace Unity.Mathematics.Editor
     [CustomPropertyDrawer(typeof(uint4x2)), CustomPropertyDrawer(typeof(uint4x3)), CustomPropertyDrawer(typeof(uint4x4))]
     class MatrixDrawer : PropertyDrawer
     {
-        [Obsolete("CanCacheInspectorGUI has been deprecated, is no longer used and will be removed in later versions.", false)]
+#if !UNITY_2023_2_OR_NEWER
         public override bool CanCacheInspectorGUI(SerializedProperty property)
         {
             return false;
         }
+#endif
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {

--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -44,11 +44,12 @@ namespace Unity.Mathematics.Editor
             public static readonly GUIContent[] labels4 = { new GUIContent("X"), new GUIContent("Y"), new GUIContent("Z"), new GUIContent("W") };
         }
 
-        [Obsolete("CanCacheInspectorGUI has been deprecated, is no longer used and will be removed in later versions.", false)]
+#if !UNITY_2023_2_OR_NEWER
         public override bool CanCacheInspectorGUI(SerializedProperty property)
         {
             return false;
         }
+#endif
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {

--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -44,6 +44,7 @@ namespace Unity.Mathematics.Editor
             public static readonly GUIContent[] labels4 = { new GUIContent("X"), new GUIContent("Y"), new GUIContent("Z"), new GUIContent("W") };
         }
 
+        [Obsolete("CanCacheInspectorGUI has been deprecated, is no longer used and will be removed in later versions.", false)]
         public override bool CanCacheInspectorGUI(SerializedProperty property)
         {
             return false;


### PR DESCRIPTION
Deprecated method warnings are trickling down into mathematics.editor code so we need to mark our methods as obsolete to signal to users to not use the methods while allowing the package to import without warning generation.