### PR TITLE
Bugfic for PostNormalizedVectorDrawer.cs tooltip display

### DIFF
--- a/src/Unity.Mathematics.Editor/PostNormalizedVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PostNormalizedVectorDrawer.cs
@@ -12,8 +12,10 @@ namespace Unity.Mathematics.Editor
     {
         static class Content
         {
-            public static readonly string tooltip =
-                L10n.Tr("Values you enter will be post-normalized. You will see the normalized result if you change selection and view the values again.");
+            public static readonly GUIContent Tooltip = new (
+                string.Empty, 
+                L10n.Tr("Values you enter will be post-normalized. You will see the normalized result if you "
+                    + "change selection and view the values again."));
         }
 
         class VectorPropertyGUIData
@@ -181,8 +183,12 @@ namespace Unity.Mathematics.Editor
                 return;
             }
 
+            // Avoid polluting the passed-in GUIContent - it might be static and shared.
             if (string.IsNullOrEmpty(label.tooltip))
-                label.tooltip = Content.tooltip;
+            {
+                Content.Tooltip.text = label.text;
+                label = Content.Tooltip;
+            }
 
             guiData.RebuildIfDirty();
             guiData.ApplyPreNormalizedValues();


### PR DESCRIPTION
## Purpose of this PR
Fix an incorrect PropertyDrawer which was sometimes writing tooltips into passed-in GUIContent objects.  This is problematic because sometimes those objects are static and get reused elsewhere.  The result was that the errant tooltip would subsequently show up in all sorts of unwanted places until you restarted Unity.

<img width="466" height="229" alt="image" src="https://github.com/user-attachments/assets/c042efe5-11bc-4b47-aca8-076c9408d09c" />

![AnnoyingToolTips](https://github.com/user-attachments/assets/e68cc687-3278-4006-83f4-51ecacfbe79c)

This can get triggered by hovering over any `PropertyField` having the `[PostNormalizeAttribute]`, such as this one:

<img width="719" height="398" alt="image" src="https://github.com/user-attachments/assets/6cdf4e8d-12cd-4849-8eed-3209314d2592" />

## Release Notes
Internal  @gregoryl:
Editor: Fixed PostNormalizedVectorDrawer to avoid injecting unwanted tooltip

## Functional Testing status
Manually tested.

## Performance Testing Status
n/a

## Overall Product Risks
Complexity: Minimal 
Halo Effect: Minimal 

## Comments to reviewers
This code is more than 7yrs old so clearly people aren't tripping over this, but I did while developing some experimental code for Motion.  Seemed like a good idea to make a fix.