### PR TITLE
PrimitiveVectorDrawer doesn't change passed-in GUIContent

### DIFF
--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -36,8 +36,8 @@ namespace Unity.Mathematics.Editor
             public static readonly string doNotNormalizeCompatibility = L10n.Tr(
                 $"{typeof(DoNotNormalizeAttribute).Name} only works with {typeof(quaternion)} and primitive vector types."
             );
-            public static readonly string doNotNormalizeTooltip =
-                L10n.Tr("This value is not normalized, which may produce unexpected results.");
+            public static readonly string doNotNormalizeContent = new GUIContent("", 
+                L10n.Tr("This value is not normalized, which may produce unexpected results."));
 
             public static readonly GUIContent[] labels2 = { new GUIContent("X"), new GUIContent("Y") };
             public static readonly GUIContent[] labels3 = { new GUIContent("X"), new GUIContent("Y"), new GUIContent("Z") };
@@ -89,8 +89,10 @@ namespace Unity.Mathematics.Editor
             }
 
             if (attribute is DoNotNormalizeAttribute && string.IsNullOrEmpty(label.tooltip))
-                label.tooltip = Content.doNotNormalizeTooltip;
-
+            {
+                doNotNormalizeContent.text = label.text;
+                label = doNotNormalizeContent;
+            }
             label = EditorGUI.BeginProperty(position, label, property);
             var valuesIterator = property.FindPropertyRelative(startIter);
             MultiPropertyField(position, subLabels, valuesIterator, label);

--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -90,8 +90,8 @@ namespace Unity.Mathematics.Editor
 
             if (attribute is DoNotNormalizeAttribute && string.IsNullOrEmpty(label.tooltip))
             {
-                doNotNormalizeContent.text = label.text;
-                label = doNotNormalizeContent;
+                Content.doNotNormalizeContent.text = label.text;
+                label = Content.doNotNormalizeContent;
             }
             label = EditorGUI.BeginProperty(position, label, property);
             var valuesIterator = property.FindPropertyRelative(startIter);

--- a/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
+++ b/src/Unity.Mathematics.Editor/PrimitiveVectorDrawer.cs
@@ -36,7 +36,7 @@ namespace Unity.Mathematics.Editor
             public static readonly string doNotNormalizeCompatibility = L10n.Tr(
                 $"{typeof(DoNotNormalizeAttribute).Name} only works with {typeof(quaternion)} and primitive vector types."
             );
-            public static readonly string doNotNormalizeContent = new GUIContent("", 
+            public static readonly GUIContent doNotNormalizeContent = new GUIContent("", 
                 L10n.Tr("This value is not normalized, which may produce unexpected results."));
 
             public static readonly GUIContent[] labels2 = { new GUIContent("X"), new GUIContent("Y") };


### PR DESCRIPTION
Same as this: https://github.com/Unity-Technologies/Unity.Mathematics/pull/250

Fix an incorrect PropertyDrawer which was sometimes writing tooltips into passed-in GUIContent objects. This is problematic because sometimes those objects are static and get reused elsewhere. The result was that the errant tooltip would subsequently show up in all sorts of unwanted places until you restarted Unity.