### PR TITLE
Add constructor for double3x3 for issue #248

### DIFF
--- a/src/Unity.Mathematics/double3x3.gen.cs
+++ b/src/Unity.Mathematics/double3x3.gen.cs
@@ -154,7 +154,14 @@ namespace Unity.Mathematics
             this.c2 = v.c2;
         }
 
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double3x3(double4x4 v)
+        {
+            this.c0 = v.c0.xyz
+            this.c1 = v.c1.xyz
+            this.c2 = v.c2.xyz
+        }
+        
         /// <summary>Implicitly converts a single double value to a double3x3 matrix by assigning it to every component.</summary>
         /// <param name="v">double to convert to double3x3</param>
         /// <returns>Converted value.</returns>
@@ -692,6 +699,7 @@ namespace Unity.Mathematics
                     fold_to_uint(v.c1) * uint3(0x5D19E1D5u, 0xFAAF07DDu, 0x625C45BDu) +
                     fold_to_uint(v.c2) * uint3(0xC9F27FCBu, 0x6D2523B1u, 0x6E2BF6A9u)) + 0xCC74B3B7u;
         }
+        
 
     }
 }

--- a/src/Unity.Mathematics/double3x3.gen.cs
+++ b/src/Unity.Mathematics/double3x3.gen.cs
@@ -157,11 +157,11 @@ namespace Unity.Mathematics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double3x3(double4x4 v)
         {
-            this.c0 = v.c0.xyz
-            this.c1 = v.c1.xyz
-            this.c2 = v.c2.xyz
+            this.c0 = v.c0.xyz;
+            this.c1 = v.c1.xyz;
+            this.c2 = v.c2.xyz;
         }
-        
+
         /// <summary>Implicitly converts a single double value to a double3x3 matrix by assigning it to every component.</summary>
         /// <param name="v">double to convert to double3x3</param>
         /// <returns>Converted value.</returns>


### PR DESCRIPTION
Added a double3x3 constructor which extracts xyz from a 4x4 double matrix, as this was implemented for floats but not doubles, as requested in #248 