### PR TITLE
Update master branch with select 1.3.2 release changes and port a Random NextFloat and NextDouble documentation update

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -27,24 +27,16 @@ upmci_platforms:
     flavor: b1.large
 
 validate_editor_versions:
-  - version: "2022.3"
-    display_name: "2022.3"
   - version: "6000.0"
     display_name: "6000.0"
   - version: "6000.3"
     display_name: "6000.3"
-  - version: "6000.4"
-    display_name: "6000.4"
 
 package_tests_editor_versions:
-  - version: "2022.3"
-    display_name: "2022.3"
   - version: "6000.0"
     display_name: "6000.0"
   - version: "6000.3"
     display_name: "6000.3"
-  - version: "6000.4"
-    display_name: "6000.4"
 ---
 
 {% for platform in upmci_platforms %}

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Fixed `math.hash` crash when using IL2CPP builds on Arm 32 bit devices.
 * Fixed obsolete method usage warnings for `MatrixDrawer.CanCacheInspectorGUI` and `PrimitiveVectorDrawer.CanCacheInspectorGUI` in UNITY_2023_2_OR_NEWER.
+* Updated minimum editor version to 2021.3
 
 ## [1.3.1] - 2023-07-12
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.3.2] - 2024-01-11
 
 ### Fixed
 * Fixed `math.hash` crash when using IL2CPP builds on Arm 32 bit devices.

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+* Added a documentation remark for Random NextFloat and NextDouble methods with a min and max parameter.
+
 ## [1.3.2] - 2024-01-11
 
 ### Fixed

--- a/src/Unity.Mathematics/random.cs
+++ b/src/Unity.Mathematics/random.cs
@@ -468,6 +468,7 @@ namespace Unity.Mathematics
         /// <param name="min">The minimum value to generate, inclusive.</param>
         /// <param name="max">The maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random float value in the range [min, max).</returns>
+        /// <remarks>The result is computed as `NextFloat() * (max - min) + min`, so floating-point rounding can in rare cases return a value equal to `max` rather than strictly less than it. Clamp the result if you require a value strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float NextFloat(float min, float max) { return NextFloat() * (max - min) + min; }
 
@@ -475,6 +476,7 @@ namespace Unity.Mathematics
         /// <param name="min">The componentwise minimum value to generate, inclusive.</param>
         /// <param name="max">The componentwise maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random float2 value in the range [min, max).</returns>
+        /// <remarks>Each component is computed as `NextFloat() * (max - min) + min`, so floating-point rounding can in rare cases return a component equal to the corresponding component of `max` rather than strictly less than it. Clamp the result if you require components strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float2 NextFloat2(float2 min, float2 max) { return NextFloat2() * (max - min) + min; }
 
@@ -482,6 +484,7 @@ namespace Unity.Mathematics
         /// <param name="min">The componentwise minimum value to generate, inclusive.</param>
         /// <param name="max">The componentwise maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random float3 value in the range [min, max).</returns>
+        /// <remarks>Each component is computed as `NextFloat() * (max - min) + min`, so floating-point rounding can in rare cases return a component equal to the corresponding component of `max` rather than strictly less than it. Clamp the result if you require components strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float3 NextFloat3(float3 min, float3 max) { return NextFloat3() * (max - min) + min; }
 
@@ -489,6 +492,7 @@ namespace Unity.Mathematics
         /// <param name="min">The componentwise minimum value to generate, inclusive.</param>
         /// <param name="max">The componentwise maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random float4 value in the range [min, max).</returns>
+        /// <remarks>Each component is computed as `NextFloat() * (max - min) + min`, so floating-point rounding can in rare cases return a component equal to the corresponding component of `max` rather than strictly less than it. Clamp the result if you require components strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float4 NextFloat4(float4 min, float4 max) { return NextFloat4() * (max - min) + min; }
 
@@ -572,6 +576,7 @@ namespace Unity.Mathematics
         /// <param name="min">The minimum value to generate, inclusive.</param>
         /// <param name="max">The maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random double value in the range [min, max).</returns>
+        /// <remarks>The result is computed as `NextDouble() * (max - min) + min`, so floating-point rounding can in rare cases return a value equal to `max` rather than strictly less than it. Clamp the result if you require a value strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double NextDouble(double min, double max) { return NextDouble() * (max - min) + min; }
 
@@ -579,6 +584,7 @@ namespace Unity.Mathematics
         /// <param name="min">The componentwise minimum value to generate, inclusive.</param>
         /// <param name="max">The componentwise maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random double2 value in the range [min, max).</returns>
+        /// <remarks>Each component is computed as `NextDouble() * (max - min) + min`, so floating-point rounding can in rare cases return a component equal to the corresponding component of `max` rather than strictly less than it. Clamp the result if you require components strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double2 NextDouble2(double2 min, double2 max) { return NextDouble2() * (max - min) + min; }
 
@@ -586,6 +592,7 @@ namespace Unity.Mathematics
         /// <param name="min">The componentwise minimum value to generate, inclusive.</param>
         /// <param name="max">The componentwise maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random double3 value in the range [min, max).</returns>
+        /// <remarks>Each component is computed as `NextDouble() * (max - min) + min`, so floating-point rounding can in rare cases return a component equal to the corresponding component of `max` rather than strictly less than it. Clamp the result if you require components strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double3 NextDouble3(double3 min, double3 max) { return NextDouble3() * (max - min) + min; }
 
@@ -593,6 +600,7 @@ namespace Unity.Mathematics
         /// <param name="min">The componentwise minimum value to generate, inclusive.</param>
         /// <param name="max">The componentwise maximum value to generate, exclusive.</param>
         /// <returns>A uniformly random double4 value in the range [min, max).</returns>
+        /// <remarks>Each component is computed as `NextDouble() * (max - min) + min`, so floating-point rounding can in rare cases return a component equal to the corresponding component of `max` rather than strictly less than it. Clamp the result if you require components strictly less than `max`.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double4 NextDouble4(double4 min, double4 max) { return NextDouble4() * (max - min) + min; }
 

--- a/src/ValidationExceptions.json
+++ b/src/ValidationExceptions.json
@@ -1,5 +1,10 @@
 {
     "ErrorExceptions": [
+        {
+            "ValidationTest": "Package Unity Version Validation",
+            "ExceptionMessage": "The Unity version requirement is more strict than in the previous version of the package. Increment the minor version of the package to leave patch versions available for previous version. Read more about this error and potential solutions at https://docs.unity3d.com/Packages/com.unity.package-validation-suite@latest/index.html?preview=1&subfolder=/manual/package_unity_version_validation_error.html#the-unity-version-requirement-is-more-strict-than-in-the-previous-version-of-the-package",
+            "PackageVersion": "1.3.2"
+        }
     ],
     "WarningExceptions": []
 }

--- a/src/ValidationExceptions.json
+++ b/src/ValidationExceptions.json
@@ -1,10 +1,4 @@
 {
-    "ErrorExceptions": [
-        {
-            "ValidationTest": "Package Unity Version Validation",
-            "ExceptionMessage": "The Unity version requirement is more strict than in the previous version of the package. Increment the minor version of the package to leave patch versions available for previous version. Read more about this error and potential solutions at https://docs.unity3d.com/Packages/com.unity.package-validation-suite@latest/index.html?preview=1&subfolder=/manual/package_unity_version_validation_error.html#the-unity-version-requirement-is-more-strict-than-in-the-previous-version-of-the-package",
-            "PackageVersion": "1.3.2"
-        }
-    ],
+    "ErrorExceptions": [],
     "WarningExceptions": []
 }

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.mathematics",
     "displayName": "Mathematics",
     "version": "1.3.2",
-    "unity": "2018.3",
+    "unity": "2021.3",
     "description": "Unity's C# SIMD math library providing vector types and math functions with a shader like syntax.",
     "keywords": [
         "unity"

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.mathematics",
     "displayName": "Mathematics",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "unity": "2018.3",
     "description": "Unity's C# SIMD math library providing vector types and math functions with a shader like syntax.",
     "keywords": [


### PR DESCRIPTION
The initial intention of the PR was to update the `master` branch with a recent Remark addition for `NextFloat` and `NextDouble` methods with `min` and `max` parameters.  It turned out the branch was not updated following the last formal package release at `1.3.2` (`1.3.3` was automatically created to account for new package signature requirements).  This PR brings in select changes from the release branch and removes some unsupported editor versions from the `upm-ci.yml`.