### PR TITLE
Bump version from 1.3.2 to 1.3.4 to resolve Package Validation CI failures

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.mathematics",
     "displayName": "Mathematics",
-    "version": "1.3.2",
+    "version": "1.3.4",
     "unity": "2021.3",
     "description": "Unity's C# SIMD math library providing vector types and math functions with a shader like syntax.",
     "keywords": [


### PR DESCRIPTION
Package Validation jobs are failing on the `master` branch, due to the cited package version coinciding with an already released package version.  This PR bumps the version to the next unreleased package version of 1.3.4.  1.3.3 was auto-released with an updated package signature and no other changes.