### PR TITLE
Backport ValidationExceptions change

### DIFF
--- a/src/ValidationExceptions.json
+++ b/src/ValidationExceptions.json
@@ -1,4 +1,10 @@
 {
-    "ErrorExceptions": [],
+    "ErrorExceptions": [
+        {
+            "ValidationTest": "Package Unity Version Validation",
+            "ExceptionMessage": "The Unity version requirement is more strict than in the previous version of the package. Increment the minor version of the package to leave patch versions available for previous version. Read more about this error and potential solutions at https://docs.unity3d.com/Packages/com.unity.package-validation-suite@latest/index.html?preview=1&subfolder=/manual/package_unity_version_validation_error.html#the-unity-version-requirement-is-more-strict-than-in-the-previous-version-of-the-package",
+            "PackageVersion": "1.3.2"
+        }
+    ],
     "WarningExceptions": []
 }


### PR DESCRIPTION
The minimum Unity version bump brought over from the release branch also required a ValidationExceptions update to account for a Package Validation job failure.