### PR TITLE
Docs bug fixes and module migration notice

### DIFF
--- a/src/Documentation~/index.md
+++ b/src/Documentation~/index.md
@@ -16,6 +16,9 @@ Plus elementary functions:
 
 You can install the Mathematics package through Unity's Package Manager. For more information, see the Unity User Manual documentation on [Adding and removing packages](https://docs.unity3d.com/Manual/upm-ui-actions.html).
 
+>[!IMPORTANT]
+>From Unity 6.5, Unity Mathematics is a built-in module of the core Editor and Engine and its APIs are available to user code by default in the `Unity.Mathematics` namespace, with no package installation required. Accordingly, from Unity 6.5 the Unity Mathematics API documentation is part of the [core Scripting API reference](https://docs.unity3d.com/ScriptReference/Unity.Mathematics.math.html), and the user manual is integrated with [the core Unity user manual](https://docs.unity3d.com/Manual/unity-mathematics.html).
+
 ### Editor config
 
 Unity Mathematics uses [editorconfig](http://editorconfig.org/) to keep files formatted for EOL and spaces.

--- a/src/Unity.Mathematics/math.cs
+++ b/src/Unity.Mathematics/math.cs
@@ -2511,7 +2511,7 @@ namespace Unity.Mathematics
         public static double4 asin(double4 x) { return new double4(asin(x.x), asin(x.y), asin(x.z), asin(x.w)); }
 
 
-        /// <summary>Returns the result of rounding a float value up to the nearest integral value less or equal to the original value.</summary>
+        /// <summary>Returns the result of rounding a float value down to the nearest integral value less or equal to the original value.</summary>
         /// <param name="x">Input value.</param>
         /// <returns>The round down to nearest integral value of the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2536,7 +2536,7 @@ namespace Unity.Mathematics
         public static float4 floor(float4 x) { return new float4(floor(x.x), floor(x.y), floor(x.z), floor(x.w)); }
 
 
-        /// <summary>Returns the result of rounding a double value up to the nearest integral value less or equal to the original value.</summary>
+        /// <summary>Returns the result of rounding a double value down to the nearest integral value less or equal to the original value.</summary>
         /// <param name="x">Input value.</param>
         /// <returns>The round down to nearest integral value of the input.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
A couple of docs changes:

- Fix copy-paste errors in descriptions for `floor` methods: round up -> round down.
- Add a note about the package's migration to a module and the relocation of the docs from Unity 6.5.